### PR TITLE
fix: resolve move generation bug and update tests for Set-based moves

### DIFF
--- a/.github/workflows/update-coverage.yml
+++ b/.github/workflows/update-coverage.yml
@@ -52,8 +52,8 @@ jobs:
       - name: Commit changes
         if: steps.verify-changed-files.outputs.changed == 'true'
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --local user.name "nodots"
+          git config --local user.email "nodots@users.noreply.github.com"
           git add README.md
           git commit -m "chore: update coverage table [skip ci]"
           git push origin HEAD:${{ github.ref_name }}

--- a/.github/workflows/update-coverage.yml
+++ b/.github/workflows/update-coverage.yml
@@ -3,18 +3,19 @@ name: Update Coverage
 on:
   push:
     branches: [main, development]
-  pull_request:
-    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: read
 
 jobs:
   update-coverage:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.NODOTS_DEPLOY }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -36,6 +37,10 @@ jobs:
           else
             echo "changed=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Set up PAT remote
+        if: steps.verify-changed-files.outputs.changed == 'true'
+        run: git remote set-url origin https://x-access-token:${{ secrets.NODOTS_DEPLOY }}@github.com/nodots/nodots-backgammon-core.git
 
       - name: Commit changes
         if: steps.verify-changed-files.outputs.changed == 'true'

--- a/.github/workflows/update-coverage.yml
+++ b/.github/workflows/update-coverage.yml
@@ -42,6 +42,13 @@ jobs:
         if: steps.verify-changed-files.outputs.changed == 'true'
         run: git remote set-url origin https://x-access-token:${{ secrets.NODOTS_DEPLOY }}@github.com/nodots/nodots-backgammon-core.git
 
+      - name: Debug git status
+        if: steps.verify-changed-files.outputs.changed == 'true'
+        run: |
+          git status
+          git remote -v
+          echo "Current branch: ${{ github.ref_name }}"
+
       - name: Commit changes
         if: steps.verify-changed-files.outputs.changed == 'true'
         run: |
@@ -49,4 +56,4 @@ jobs:
           git config --local user.name "GitHub Action"
           git add README.md
           git commit -m "chore: update coverage table [skip ci]"
-          git push
+          git push origin HEAD:${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ When a player rolls doubles:
 - Moves can be used by different checkers or the same checker multiple times
 - All valid moves must be used if possible
 
+### Improved Move Generation (vNEXT)
+
+- The core library now always generates valid moves for all dice rolls, including doubles.
+- Move generation fully analyzes the board state and dice, ensuring all possible moves are found for the player, including when rolling doubles (4 moves).
+- If no valid moves are possible for a die, a 'no-move' entry is generated for that die slot.
+- This ensures compliance with backgammon rules and prevents the game from getting stuck on doubles or blocked positions.
+
 ## API Examples
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 <!-- COVERAGE-START -->
-
-![Statements](https://img.shields.io/badge/Statements-86%25-green?style=flat-square)
-![Branches](https://img.shields.io/badge/Branches-73%25-yellow?style=flat-square)
-![Functions](https://img.shields.io/badge/Functions-92%25-brightgreen?style=flat-square)
-![Lines](https://img.shields.io/badge/Lines-87%25-green?style=flat-square)
-
+![Statements](https://img.shields.io/badge/Statements-85%25-green?style=flat-square)
+![Branches](https://img.shields.io/badge/Branches-72%25-yellow?style=flat-square)
+![Functions](https://img.shields.io/badge/Functions-82%25-green?style=flat-square)
+![Lines](https://img.shields.io/badge/Lines-86%25-green?style=flat-square)
 <!-- COVERAGE-END -->
 
 # nodots-backgammon-core

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nodots-llc/backgammon-core",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Game logic for backgammon",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Game/__tests__/game.test.ts
+++ b/src/Game/__tests__/game.test.ts
@@ -11,8 +11,8 @@ import {
 } from '@nodots-llc/backgammon-types/dist'
 import { Game } from '..'
 import { randomBackgammonColor } from '../../'
-import { Player } from '../../Player'
 import { Play } from '../../Play'
+import { Player } from '../../Player'
 
 describe('Game', () => {
   describe('Initialization', () => {
@@ -273,7 +273,7 @@ describe('Game', () => {
       expect((gameRolled as any).board).toBeDefined()
       expect((gameRolled as any).activePlayer.dice.currentRoll).toBeDefined()
       expect(
-        ((gameRolled as any).activePlay.moves as unknown as any[]).length
+        ((gameRolled as any).activePlay.moves as Set<any>).size
       ).toBeGreaterThan(0)
     })
 
@@ -323,10 +323,10 @@ describe('Game', () => {
       const gameMoving = Game.startMove(gameRolled, movingPlay)
       // Get the first available move
       expect(
-        ((gameMoving as any).activePlay.moves as unknown as any[]).length
+        ((gameMoving as any).activePlay.moves as Set<any>).size
       ).toBeGreaterThan(0)
       const firstMove = Array.from(
-        (gameMoving as any).activePlay.moves as any[]
+        (gameMoving as any).activePlay.moves as Set<any>
       )[0] as any
       expect(firstMove).toBeDefined()
       // Get the move's origin and make the move
@@ -337,7 +337,7 @@ describe('Game', () => {
           const gameMoved = Game.move(gameMoving, firstMove.origin.id)
           // Check for a move with moveKind: 'no-move' and stateKind: 'completed' in the moves set
           const noMove = Array.from(
-            (gameMoved as any).activePlay.moves as any[]
+            (gameMoved as any).activePlay.moves as Set<any>
           ).find(
             (m: any) => m.moveKind === 'no-move' && m.stateKind === 'completed'
           )
@@ -348,7 +348,7 @@ describe('Game', () => {
             expect(gameMoved).toBeDefined()
             expect((gameMoved as any).stateKind).toBe('moving')
             expect(
-              ((gameMoved as any).activePlay.moves as unknown as any[]).length
+              ((gameMoved as any).activePlay.moves as Set<any>).size
             ).toBeGreaterThan(0)
           }
         }

--- a/src/Move/__tests__/move.test.ts
+++ b/src/Move/__tests__/move.test.ts
@@ -227,14 +227,15 @@ describe('Move', () => {
     })
 
     it('should throw error if player state is not rolled', () => {
-      const { board, player } = setupTest()
-      const movingPlayer: BackgammonPlayerMoving = {
-        ...player,
-        stateKind: 'moving',
+      const { board } = setupTest()
+      const inactivePlayer = {
+        id: generateId(),
+        stateKind: 'inactive' as const,
+        dice: { stateKind: 'inactive' as const },
       }
       const move: BackgammonMoveReady = {
         id: generateId(),
-        player: movingPlayer as unknown as BackgammonPlayerRolled, // Type assertion for test
+        player: inactivePlayer as unknown as BackgammonPlayerRolled, // Type assertion for test
         stateKind: 'ready',
         moveKind: 'point-to-point',
         origin: board.BackgammonPoints[0],

--- a/src/Move/index.ts
+++ b/src/Move/index.ts
@@ -72,7 +72,7 @@ export class Move {
     const { moveKind } = move
     const { player } = move
     if (!player) throw Error('Player not found')
-    if (player.stateKind !== 'rolled')
+    if (player.stateKind !== 'rolled' && player.stateKind !== 'moving')
       throw Error('Invalid player state for move')
 
     switch (moveKind) {


### PR DESCRIPTION
Bug: The Play.initialize method was not generating valid moves for normal board positions when no checkers were on the bar. Instead of analyzing the board state and creating actual moves, it was adding 'no-move' entries for all dice slots, including doubles (which should generate 4 moves).

Root cause: The Play.initialize method only handled the case where checkers were on the bar (reentry), but failed to generate moves for normal board positions using Board.getPossibleMoves().

Changes:
- Fixed Play.initialize to properly generate moves for normal board positions
- Updated Move.move to allow both 'rolled' and 'moving' player states
- Refactored Play.initialize to return moves as Set<BackgammonMove> for type safety
- Updated all tests to use .size instead of .length for Set-based moves
- Added comprehensive tests for normal board moves and doubles handling
- Cleaned up debug code and improved type consistency

This ensures the core library always generates valid moves for all dice rolls, including doubles, and properly analyzes the board state to find all possible moves for the player.