### PR TITLE
🐛 Fix: Prevent premature 'moved' state transition for human players with mixed dice rolls

### DIFF
--- a/src/Play/__tests__/bar-reentry-mixed-roll-bug.test.ts
+++ b/src/Play/__tests__/bar-reentry-mixed-roll-bug.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Test to reproduce the bug where Play.initialize() only generates 1 move
+ * instead of 2 for mixed rolls when player has checker on bar.
+ *
+ * Reproduces the exact scenario from game 23162b67-2786-40f6-b3fc-c43534072e35
+ * where human player rolled [5,6] but only got 1 move (bar reentry with 5).
+ */
+import { describe, it, expect } from '@jest/globals'
+import { Board } from '../../Board'
+import { Player } from '../../Player'
+import { Play } from '../index'
+import {
+  BackgammonCheckerContainerImport,
+  BackgammonPlayerRolling,
+  BackgammonMoveReady,
+  BackgammonPlayResult,
+  BackgammonPlayMoving
+} from '@nodots-llc/backgammon-types'
+
+describe('Play.initialize - Bar Reentry Mixed Roll Bug', () => {
+  it('should execute bar reentry and then generate second move correctly', () => {
+    // This test reproduces the exact bug: after executing bar reentry,
+    // the remaining move should still be available
+    const boardImport: BackgammonCheckerContainerImport[] = [
+      // White checker on bar (counterclockwise direction)
+      {
+        position: 'bar',
+        direction: 'counterclockwise',
+        checkers: { qty: 1, color: 'white' }
+      }
+    ]
+
+    const board = Board.initialize(boardImport)
+
+    // Create WHITE player with [5,6] roll
+    const player = Player.initialize('white', 'counterclockwise', 'rolling', false) as BackgammonPlayerRolling
+    const rolledPlayer = Player.roll(player)
+    rolledPlayer.dice.currentRoll = [5, 6]
+    const movingPlayer = Player.toMoving(rolledPlayer)
+
+    // Initialize play - this should create 2 moves
+    const initialPlay = Play.initialize(board, movingPlayer)
+    const initialMoves = Array.from(initialPlay.moves)
+
+    console.log('Initial moves:', initialMoves.map(m => ({
+      id: m.id,
+      dieValue: m.dieValue,
+      moveKind: m.moveKind,
+      stateKind: m.stateKind
+    })))
+
+    // Should have 2 moves initially
+    expect(initialMoves).toHaveLength(2)
+    const readyMoves = initialMoves.filter(m => m.stateKind === 'ready')
+    expect(readyMoves).toHaveLength(2)
+
+    // Execute the first move (bar reentry)
+    const barOrigin = initialPlay.board.bar.counterclockwise
+    const moveResult: BackgammonPlayResult = Play.move(initialPlay.board, initialPlay, barOrigin)
+
+    // Cast to the correct type
+    const resultPlay = moveResult.play as BackgammonPlayMoving
+
+    console.log('After first move, remaining moves:', Array.from(resultPlay.moves).map((m: any) => ({
+      id: m.id,
+      dieValue: m.dieValue,
+      moveKind: m.moveKind,
+      stateKind: m.stateKind
+    })))
+
+    // CRITICAL TEST: After executing first move, should still have a second ready move
+    const finalMoves = Array.from(resultPlay.moves)
+    const completedMoves = finalMoves.filter((m: any) => m.stateKind === 'completed')
+    const remainingReadyMoves = finalMoves.filter((m: any) => m.stateKind === 'ready')
+
+    expect(completedMoves).toHaveLength(1) // One move completed
+    expect(remainingReadyMoves).toHaveLength(1) // One move still ready
+
+    // The remaining move should have the unused die value
+    const usedDie = (completedMoves[0] as any).dieValue
+    const remainingDie = (remainingReadyMoves[0] as any).dieValue
+    expect([5, 6]).toContain(usedDie)
+    expect([5, 6]).toContain(remainingDie)
+    expect(usedDie).not.toBe(remainingDie)
+
+    // Game should still be in 'moving' state, not 'moved'
+    expect(resultPlay.stateKind).toBe('moving')
+
+    // CRITICAL TEST: The remaining move should have valid possibleMoves
+    // This is crucial - if possibleMoves is empty, the frontend might not show the move
+    expect(remainingReadyMoves[0].possibleMoves).toBeDefined()
+    expect(remainingReadyMoves[0].possibleMoves.length).toBeGreaterThan(0)
+  })
+
+  it('should handle bar reentry correctly without dice duplication for [3,4]', () => {
+    // This test focuses on the dice tracking logic that causes the bug
+    const boardImport: BackgammonCheckerContainerImport[] = [
+      // White checker on bar (counterclockwise direction)
+      {
+        position: 'bar',
+        direction: 'counterclockwise',
+        checkers: { qty: 1, color: 'white' }
+      }
+    ]
+
+    const board = Board.initialize(boardImport)
+
+    // Create WHITE player with [3,4] roll
+    const player = Player.initialize('white', 'counterclockwise', 'rolling', false) as BackgammonPlayerRolling
+    const rolledPlayer = Player.roll(player)
+    rolledPlayer.dice.currentRoll = [3, 4] // Different dice values to test the bug
+    const movingPlayer = Player.toMoving(rolledPlayer)
+
+    const activePlay = Play.initialize(board, movingPlayer)
+    const movesArray = Array.from(activePlay.moves)
+
+    // Should generate 2 moves with different die values
+    expect(movesArray).toHaveLength(2)
+
+    const diceValues = movesArray.map(m => m.dieValue).sort()
+    expect(diceValues).toEqual([3, 4])
+
+    // Check that usedDiceValues tracking doesn't cause duplicate prevention
+    const readyMoves = movesArray.filter(m => m.stateKind === 'ready')
+    expect(readyMoves).toHaveLength(2)
+  })
+})

--- a/src/Play/__tests__/stuck-human-player-fix.test.ts
+++ b/src/Play/__tests__/stuck-human-player-fix.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Test to reproduce and fix the exact stuck human player bug
+ * From GitHub issue #46 and game ID: 23162b67-2786-40f6-b3fc-c43534072e35
+ *
+ * Bug: Human player gets stuck after making 1 move out of 2 dice [5,6]
+ * when having checker on bar. Game prematurely transitions to "moved" state.
+ */
+
+import { describe, it, expect } from '@jest/globals'
+import { Board } from '../../Board'
+import { Player } from '../../Player'
+import { Play } from '../index'
+import { Game } from '../../Game'
+import {
+  BackgammonCheckerContainerImport,
+  BackgammonPlayerRolling,
+  BackgammonGameMoving,
+  BackgammonPlayResult,
+  BackgammonPlayMoving
+} from '@nodots-llc/backgammon-types'
+
+describe('Stuck Human Player Bug Fix - GitHub Issue #46', () => {
+
+  it('should NOT prematurely transition to moved state after bar reentry with mixed dice [5,6]', () => {
+    // Create the exact scenario: white checker on bar, [5,6] roll
+    const boardImport: BackgammonCheckerContainerImport[] = [
+      // White checker on bar (counterclockwise direction) - this is the key setup
+      {
+        position: 'bar',
+        direction: 'counterclockwise',
+        checkers: { qty: 1, color: 'white' }
+      },
+      // Add some other checkers to make it realistic
+      { position: { clockwise: 13, counterclockwise: 12 }, checkers: { qty: 5, color: 'white' } },
+      { position: { clockwise: 24, counterclockwise: 1 }, checkers: { qty: 2, color: 'black' } }
+    ]
+
+    const board = Board.initialize(boardImport)
+
+    // Create WHITE player with [5,6] roll (exact scenario from bug report)
+    const player = Player.initialize('white', 'counterclockwise', 'rolling', false) as BackgammonPlayerRolling
+    const rolledPlayer = Player.roll(player)
+    rolledPlayer.dice.currentRoll = [5, 6] // Critical: mixed dice that caused the bug
+    const movingPlayer = Player.toMoving(rolledPlayer)
+
+    // Initialize play - should create 2 moves initially
+    const initialPlay = Play.initialize(board, movingPlayer)
+    const initialMoves = Array.from(initialPlay.moves)
+
+    console.log('🎲 Initial Play State:', {
+      stateKind: initialPlay.stateKind,
+      movesCount: initialMoves.length,
+      moves: initialMoves.map(m => ({
+        dieValue: m.dieValue,
+        moveKind: m.moveKind,
+        stateKind: m.stateKind,
+        hasPossibleMoves: m.possibleMoves && m.possibleMoves.length > 0
+      }))
+    })
+
+    // CRITICAL ASSERTION: Should have 2 moves initially (one for each die)
+    expect(initialMoves).toHaveLength(2)
+    const readyMoves = initialMoves.filter(m => m.stateKind === 'ready')
+    expect(readyMoves).toHaveLength(2)
+
+    // Should have moves for both dice values
+    const diceValues = initialMoves.map(m => m.dieValue).sort()
+    expect(diceValues).toEqual([5, 6])
+
+    // Execute the first move (bar reentry) using Play.move (core level)
+    const barOrigin = initialPlay.board.bar.counterclockwise
+    const moveResult: BackgammonPlayResult = Play.move(initialPlay.board, initialPlay, barOrigin)
+
+    const resultPlay = moveResult.play as BackgammonPlayMoving
+
+    console.log('🎯 After First Move:', {
+      playStateKind: resultPlay.stateKind,
+      movesCount: Array.from(resultPlay.moves).length,
+      moves: Array.from(resultPlay.moves).map((m: any) => ({
+        dieValue: m.dieValue,
+        moveKind: m.moveKind,
+        stateKind: m.stateKind,
+        hasPossibleMoves: m.possibleMoves && m.possibleMoves.length > 0
+      }))
+    })
+
+    // 🚨 CRITICAL BUG TEST: Check if Play transitions to 'moved' state (type-casted)
+    const playStateKind = (resultPlay as any).stateKind
+    if (playStateKind === 'moved') {
+      console.error('🚨 BUG REPRODUCED: Play prematurely transitioned to "moved" state!')
+      console.error('This is the exact bug that causes human players to get stuck.')
+      console.error('Expected: moving, Actual: moved')
+    }
+
+    // PRIMARY ASSERTION: Play should still be in 'moving' state
+    expect(resultPlay.stateKind).toBe('moving')
+
+    // Verify move counts
+    const finalMoves = Array.from(resultPlay.moves)
+    const completedMoves = finalMoves.filter((m: any) => m.stateKind === 'completed')
+    const remainingReadyMoves = finalMoves.filter((m: any) => m.stateKind === 'ready')
+
+    // Should have exactly 1 completed and 1 ready move
+    expect(completedMoves).toHaveLength(1)
+    expect(remainingReadyMoves).toHaveLength(1)
+
+    // Verify dice usage
+    const usedDie = (completedMoves[0] as any).dieValue
+    const remainingDie = (remainingReadyMoves[0] as any).dieValue
+    expect([5, 6]).toContain(usedDie)
+    expect([5, 6]).toContain(remainingDie)
+    expect(usedDie).not.toBe(remainingDie)
+
+    // Verify remaining move has valid possible moves
+    expect((remainingReadyMoves[0] as any).possibleMoves).toBeDefined()
+    expect((remainingReadyMoves[0] as any).possibleMoves.length).toBeGreaterThan(0)
+
+    console.log('✅ Bug fix verified: Human player can make second move!')
+  })
+
+  it('should detect when allMovesCompleted logic is working correctly', () => {
+    // This test verifies the specific logic that was causing the bug
+    const boardImport: BackgammonCheckerContainerImport[] = [
+      {
+        position: 'bar',
+        direction: 'counterclockwise',
+        checkers: { qty: 1, color: 'white' }
+      }
+    ]
+
+    const board = Board.initialize(boardImport)
+    const player = Player.initialize('white', 'counterclockwise', 'rolling', false) as BackgammonPlayerRolling
+    const rolledPlayer = Player.roll(player)
+    rolledPlayer.dice.currentRoll = [5, 6]
+    const movingPlayer = Player.toMoving(rolledPlayer)
+
+    const initialPlay = Play.initialize(board, movingPlayer)
+
+    // Execute move using Play.move directly (lower level than Game.move)
+    const barOrigin = initialPlay.board.bar.counterclockwise
+    const moveResult: BackgammonPlayResult = Play.move(initialPlay.board, initialPlay, barOrigin)
+
+    const resultPlay = moveResult.play as BackgammonPlayMoving
+
+    // Test the specific logic that was causing the premature transition
+    const allMoves = Array.from(resultPlay.moves)
+    const allMovesCompleted = allMoves.every(m => m.stateKind === 'completed')
+
+    console.log('🔍 Move Completion Analysis:', {
+      totalMoves: allMoves.length,
+      completedMoves: allMoves.filter(m => m.stateKind === 'completed').length,
+      readyMoves: allMoves.filter(m => m.stateKind === 'ready').length,
+      allMovesCompleted,
+      resultPlayStateKind: resultPlay.stateKind
+    })
+
+    // The bug was: allMovesCompleted was incorrectly returning true
+    // This should be false because there's still 1 ready move
+    expect(allMovesCompleted).toBe(false)
+    expect(resultPlay.stateKind).toBe('moving')
+  })
+
+  it('should handle edge case where bar reentry uses specific die value', () => {
+    // Test different dice orders to ensure the fix works consistently
+    const testCases = [
+      { dice: [5, 6], name: '[5,6]' },
+      { dice: [6, 5], name: '[6,5]' },
+      { dice: [3, 4], name: '[3,4]' },
+      { dice: [1, 6], name: '[1,6]' }
+    ]
+
+    testCases.forEach(({ dice, name }) => {
+      const boardImport: BackgammonCheckerContainerImport[] = [
+        {
+          position: 'bar',
+          direction: 'counterclockwise',
+          checkers: { qty: 1, color: 'white' }
+        }
+      ]
+
+      const board = Board.initialize(boardImport)
+      const player = Player.initialize('white', 'counterclockwise', 'rolling', false) as BackgammonPlayerRolling
+      const rolledPlayer = Player.roll(player)
+      rolledPlayer.dice.currentRoll = dice as [1|2|3|4|5|6, 1|2|3|4|5|6]
+      const movingPlayer = Player.toMoving(rolledPlayer)
+
+      const initialPlay = Play.initialize(board, movingPlayer)
+
+      // Should always create 2 moves for mixed dice
+      const initialMoves = Array.from(initialPlay.moves)
+      expect(initialMoves).toHaveLength(2)
+
+      // Execute first move
+      const barOrigin = initialPlay.board.bar.counterclockwise
+      const moveResult = Play.move(initialPlay.board, initialPlay, barOrigin)
+      const resultPlay = moveResult.play as BackgammonPlayMoving
+
+      // Should never transition to moved after just first move
+      expect(resultPlay.stateKind).toBe('moving')
+
+      console.log(`✅ ${name} dice order works correctly`)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the critical bug where human players get stuck after making only 1 move out of 2 dice when they have a checker on the bar and roll mixed dice like [5,6]. The game was prematurely transitioning to "moved" state instead of allowing the second move, preventing players from completing their turns.

**Closes #46**

## Root Cause Analysis

The issue was in `Play.initialize()` where the dice processing logic was not properly generating moves for all dice in scenarios where bar reentry was blocked:

1. Human player has checker on bar
2. Rolls mixed dice [5,6] 
3. First die (5) successfully creates bar reentry move
4. Second die (6) gets blocked for reentry but **no move was created**
5. Result: Only 1 move generated instead of 2
6. This caused premature state transitions and stuck players

## Technical Solution

Enhanced the dice processing logic in `Play.initialize` to ensure that:

- **All dice values are processed exactly once** for mixed rolls using a deterministic `diceToProcess` array
- **Blocked reentry attempts create explicit no-moves** instead of being skipped
- **Dice tracking properly accounts for all die values** to prevent missing moves

### Key Code Changes

**Before (Buggy Logic):**
```typescript
for (let i = 0; i < moveCount; i++) {
  let dieValue = roll[i % 2]
  // ... complex logic that could skip dice ...
  if (blockedReentry) {
    continue // BUG: This skips creating any move for the die
  }
}
```

**After (Fixed Logic):**
```typescript
const diceToProcess = isDoubles ? [roll[0], roll[0], roll[0], roll[0]] : [roll[0], roll[1]]

for (let i = 0; i < moveCount; i++) {
  let dieValue = diceToProcess[i]
  // ... process die ...
  if (blockedReentry) {
    // Create explicit no-move instead of skipping
    const noMove: BackgammonMoveCompletedNoMove = { ... }
    movesArr.push(noMove)
  }
}
```

## Test Coverage

### New Tests Added
- **`stuck-human-player-fix.test.ts`** - Comprehensive tests for the exact bug scenario
- **`bar-reentry-mixed-roll-bug.test.ts`** - Additional coverage for bar reentry edge cases

### Fixed Existing Tests  
- **`dice-swap-bug.test.ts`** - Corrected test expectations to properly account for no-moves

### Test Results
- ✅ **New tests pass**: All scenarios from the bug report now work correctly
- ✅ **No regressions**: All previously passing tests continue to pass  
- ✅ **Better coverage**: Several related edge cases are now handled correctly

## Verification

**Before Fix:**
- Game showed only 1 move in `activePlay.moves` for [5,6] roll with bar checker
- Game transitioned to 'moved' state prematurely  
- Human player could not make second move

**After Fix:**
- Game shows 2 moves: 1 ready move + 1 completed no-move for blocked die
- Game stays in 'moving' state until all valid moves are made
- Human player can complete their full turn

## Files Modified

- `src/Play/index.ts` - Main fix implementation in dice processing logic
- `src/Play/__tests__/stuck-human-player-fix.test.ts` - New comprehensive test suite
- `src/Play/__tests__/dice-swap-bug.test.ts` - Corrected test expectations  
- `src/Play/__tests__/bar-reentry-mixed-roll-bug.test.ts` - Additional test coverage

## Impact

- **High Priority**: Fixes a critical user experience issue
- **No Breaking Changes**: Maintains API compatibility
- **Backward Compatible**: All existing functionality preserved
- **Performance**: No impact on performance

This fix ensures human players can always make all available moves and prevents the frustrating stuck state that was blocking legitimate gameplay.