### PR TITLE
fix: resolve dice auto-switch and bar reentry move state bugs

### DIFF
--- a/src/Play/__tests__/bar-reentry-blocked-die.test.ts
+++ b/src/Play/__tests__/bar-reentry-blocked-die.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Test for the bug where a die that cannot be used for bar reentry
+ * is marked as no-move instead of being available for regular moves
+ * after successful reentry with the other die.
+ *
+ * Reproduces scenario from game 7d409f85-1a45-4845-9534-b1cbcbd01550:
+ * - White checker on bar
+ * - Rolled [1, 3]
+ * - Point 24 (ccw) blocked by 3 black checkers -> die 1 cannot reenter
+ * - Point 22 (ccw) open -> die 3 CAN reenter
+ * - After reentering with 3, die 1 should be available for regular move
+ */
+import { describe, it, expect } from '@jest/globals'
+import { Board } from '../../Board'
+import { Player } from '../../Player'
+import { Play } from '../index'
+import {
+  BackgammonCheckerContainerImport,
+  BackgammonPlayerRolling,
+  BackgammonMoveReady,
+} from '@nodots-llc/backgammon-types'
+
+describe('Play.initialize - Blocked Bar Reentry Should Allow Regular Move', () => {
+  it('should allow die 1 for regular move after die 3 reentry when die 1 cannot reenter', () => {
+    // Reproduce exact scenario: white on bar, point 24 blocked, point 22 open
+    const boardImport: BackgammonCheckerContainerImport[] = [
+      // White checker on bar (counterclockwise direction)
+      {
+        position: 'bar',
+        direction: 'counterclockwise',
+        checkers: { qty: 1, color: 'white' },
+      },
+      // Point 24 (ccw) / Point 1 (cw) - blocked by 3 black checkers
+      {
+        position: { clockwise: 1, counterclockwise: 24 },
+        checkers: { qty: 3, color: 'black' },
+      },
+      // Point 22 (ccw) / Point 3 (cw) - open (will receive the reentering checker)
+      {
+        position: { clockwise: 3, counterclockwise: 22 },
+        checkers: { qty: 0, color: 'white' },
+      },
+    ]
+
+    const board = Board.initialize(boardImport)
+
+    // Create WHITE player with [1, 3] roll
+    const player = Player.initialize(
+      'white',
+      'counterclockwise',
+      'rolling',
+      false
+    ) as BackgammonPlayerRolling
+    const rolledPlayer = Player.roll(player)
+    rolledPlayer.dice.currentRoll = [1, 3]
+    const movingPlayer = Player.toMoving(rolledPlayer)
+
+    // Initialize play
+    const initialPlay = Play.initialize(board, movingPlayer)
+    const initialMoves = Array.from(initialPlay.moves)
+
+    console.log(
+      'Initial moves:',
+      initialMoves.map((m) => ({
+        dieValue: m.dieValue,
+        moveKind: m.moveKind,
+        stateKind: m.stateKind,
+        possibleMovesCount: m.possibleMoves.length,
+      }))
+    )
+
+    // Should have 2 moves
+    expect(initialMoves).toHaveLength(2)
+
+    // Find the moves by die value
+    const die1Move = initialMoves.find((m) => m.dieValue === 1)
+    const die3Move = initialMoves.find((m) => m.dieValue === 3)
+
+    expect(die1Move).toBeDefined()
+    expect(die3Move).toBeDefined()
+
+    // Die 3 should be a reentry move (can reenter to point 22)
+    expect(die3Move!.moveKind).toBe('reenter')
+    expect(die3Move!.stateKind).toBe('ready')
+    expect(die3Move!.possibleMoves.length).toBeGreaterThan(0)
+
+    // CRITICAL: Die 1 should NOT be marked as no-move
+    // Instead, it should be evaluated for regular moves after simulated reentry
+    // After die 3 reenters to point 22, die 1 can move from point 22 to point 23
+    expect(die1Move!.stateKind).toBe('ready')
+    expect(die1Move!.possibleMoves.length).toBeGreaterThan(0)
+
+    // Die 1 should be a point-to-point move (not reenter, not no-move)
+    // It's evaluated on the simulated board after reentry
+    expect(die1Move!.moveKind).not.toBe('no-move')
+  })
+
+  it('should mark both dice as no-move when both are blocked for reentry and no moves possible after', () => {
+    // Edge case: both dice blocked for reentry AND no regular moves possible
+    const boardImport: BackgammonCheckerContainerImport[] = [
+      // White checker on bar
+      {
+        position: 'bar',
+        direction: 'counterclockwise',
+        checkers: { qty: 1, color: 'white' },
+      },
+      // Block all entry points for a [1, 2] roll
+      {
+        position: { clockwise: 1, counterclockwise: 24 },
+        checkers: { qty: 3, color: 'black' },
+      },
+      {
+        position: { clockwise: 2, counterclockwise: 23 },
+        checkers: { qty: 3, color: 'black' },
+      },
+    ]
+
+    const board = Board.initialize(boardImport)
+
+    const player = Player.initialize(
+      'white',
+      'counterclockwise',
+      'rolling',
+      false
+    ) as BackgammonPlayerRolling
+    const rolledPlayer = Player.roll(player)
+    rolledPlayer.dice.currentRoll = [1, 2]
+    const movingPlayer = Player.toMoving(rolledPlayer)
+
+    const initialPlay = Play.initialize(board, movingPlayer)
+    const initialMoves = Array.from(initialPlay.moves)
+
+    // Both moves should be no-move since both entry points are blocked
+    expect(initialMoves).toHaveLength(2)
+    expect(initialMoves.every((m) => m.moveKind === 'no-move')).toBe(true)
+    expect(initialMoves.every((m) => m.stateKind === 'completed')).toBe(true)
+  })
+})

--- a/src/Play/__tests__/dice-auto-switch-remaining-move.test.ts
+++ b/src/Play/__tests__/dice-auto-switch-remaining-move.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Test for the bug where after dice auto-switching occurs during first move,
+ * the remaining die value is incorrectly marked as no-move or has wrong value.
+ *
+ * Your hunch: "The same bug would present itself in a regular point-to-point move
+ * if the user attempted to move a checker on the first move that can only be moved
+ * with the dieValue in the second move."
+ */
+import { describe, it, expect } from '@jest/globals'
+import { Board } from '../../Board'
+import { Player } from '../../Player'
+import { Play } from '../index'
+import {
+  BackgammonCheckerContainerImport,
+  BackgammonPlayerRolling,
+  BackgammonPlayMoving,
+  BackgammonPlayResult,
+} from '@nodots-llc/backgammon-types'
+
+describe('Play - Dice Auto-Switch Remaining Move Bug', () => {
+  it('should preserve remaining die value after auto-switch on first move', () => {
+    // Setup: White has checker on point 20, rolled [1, 3]
+    // Point 21 is blocked (cannot use die 1)
+    // Point 23 is open (can use die 3)
+    // User clicks checker on point 20, which forces auto-switch to use die 3
+    // After move, die 1 should still be available for other checkers
+
+    const boardImport: BackgammonCheckerContainerImport[] = [
+      // White checker on point 20 (ccw) - can ONLY move with die 3, not die 1
+      {
+        position: { clockwise: 5, counterclockwise: 20 },
+        checkers: { qty: 1, color: 'white' },
+      },
+      // Point 19 (ccw) blocked - prevents die 1 move from point 20
+      {
+        position: { clockwise: 6, counterclockwise: 19 },
+        checkers: { qty: 2, color: 'black' },
+      },
+      // Point 17 (ccw) open - allows die 3 move from point 20
+      {
+        position: { clockwise: 8, counterclockwise: 17 },
+        checkers: { qty: 0, color: 'white' },
+      },
+      // Another white checker on point 10 that CAN use die 1
+      {
+        position: { clockwise: 15, counterclockwise: 10 },
+        checkers: { qty: 1, color: 'white' },
+      },
+    ]
+
+    const board = Board.initialize(boardImport)
+
+    const player = Player.initialize(
+      'white',
+      'counterclockwise',
+      'rolling',
+      false
+    ) as BackgammonPlayerRolling
+    const rolledPlayer = Player.roll(player)
+    rolledPlayer.dice.currentRoll = [1, 3]
+    const movingPlayer = Player.toMoving(rolledPlayer)
+
+    // Initialize play
+    const initialPlay = Play.initialize(board, movingPlayer)
+
+    console.log('Initial moves:', initialPlay.moves.map(m => ({
+      dieValue: m.dieValue,
+      stateKind: m.stateKind,
+      moveKind: m.moveKind,
+      possibleMovesCount: m.possibleMoves.length,
+    })))
+
+    // User clicks checker on point 20 (which can only move with die 3, not die 1)
+    const point20 = board.points.find(
+      p => p.position.counterclockwise === 20
+    )!
+
+    // Execute first move - should auto-switch to use die 3
+    const moveResult: BackgammonPlayResult = Play.move(
+      initialPlay.board,
+      initialPlay,
+      point20
+    )
+
+    const resultPlay = moveResult.play as BackgammonPlayMoving
+
+    console.log('After first move:', resultPlay.moves.map(m => ({
+      dieValue: m.dieValue,
+      stateKind: m.stateKind,
+      moveKind: m.moveKind,
+      possibleMovesCount: m.possibleMoves.length,
+    })))
+
+    // CRITICAL: After first move, die 1 should still be available
+    const remainingMoves = resultPlay.moves.filter(m => m.stateKind === 'ready')
+    expect(remainingMoves).toHaveLength(1)
+
+    const remainingMove = remainingMoves[0]
+    expect(remainingMove.dieValue).toBe(1)
+    expect(remainingMove.stateKind).toBe('ready')
+    expect(remainingMove.possibleMoves.length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary
Fixes two critical bugs in Play move management that caused incorrect die values and missing moves after dice auto-switching and bar reentry scenarios.

### Bug 1: Dice Auto-Switch State Management
**Problem:** After auto-switching dice during move execution, remaining moves had die values incorrectly reassigned by array index instead of preserving their original values from initialization.

**Fix:**
- Removed die value reassignment logic in `planMoveExecution()`
- Changed target move finding to match by die value AND origin (handles doubles correctly)
- Remaining moves now preserve their original die values from initialization

### Bug 2: Bar Reentry Move Initialization  
**Problem:** When a die couldn't reenter from bar, it was prematurely marked as no-move instead of being evaluated for regular moves after successful reentry with the other die. The root cause was 280+ lines of complex procedural code with loops, mutations, and scattered logic.

**Fix:** Completely refactored `Play.initialize()` into clean, functional approach:
- **`partitionMovesForBarReentry()`**: Separates reentry moves from regular moves
- **`simulateMoves()`**: Simulates board state after reentries  
- **`createMovesForDiceValues()`**: Creates moves for given dice on given board

Benefits:
- Eliminates 280+ lines of procedural code → 70 lines of clear functional code
- Naturally handles bar reentry: reentries evaluated first, then regular moves on simulated board
- Much easier to understand, test, and maintain

## Test Coverage
**Tests Added:**
- `bar-reentry-blocked-die.test.ts`: Verifies blocked reentry die can be used for regular moves
- `dice-auto-switch-remaining-move.test.ts`: Verifies remaining die value preserved after auto-switch

**Test Results:**
✅ All 59 Play tests pass  
✅ Both new tests pass  
✅ No regressions

## Reproduces Fix For
- Game `7d409f85-1a45-4845-9534-b1cbcbd01550` where white player couldn't use die value 1 after reentering with die value 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)