### PR TITLE
feat: implement Crawford and Jacoby rule enforcement

### DIFF
--- a/src/Game/__tests__/crawford-jacoby-rules.test.ts
+++ b/src/Game/__tests__/crawford-jacoby-rules.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from '@jest/globals'
+import { BackgammonGame } from '@nodots-llc/backgammon-types'
+import { Game } from '../index'
+
+describe('Crawford and Jacoby Rules', () => {
+  describe('Crawford Rule - Doubling Blocked During Crawford Game', () => {
+    it('should block doubling when Crawford rule is enabled and isCrawford is true', () => {
+      // Create a game
+      const game = Game.createNewGame(
+        { userId: 'player1', isRobot: false },
+        { userId: 'player2', isRobot: false }
+      )
+
+      // Roll for start and then roll to get into rolling state
+      const rolledForStart = Game.rollForStart(game)
+      const rolled = Game.roll(rolledForStart)
+
+      // Inject Crawford rule after game is setup
+      // We'll test canOfferDouble on a rolling state game
+      const gameInRolling: BackgammonGame = {
+        ...rolled,
+        stateKind: 'rolling', // Force to rolling state for testing
+        rules: {
+          useCrawfordRule: true,
+        },
+        matchInfo: {
+          matchId: 'test-match-1',
+          gameNumber: 3,
+          matchLength: 5,
+          matchScore: { white: 3, black: 2 },
+          isCrawford: true,
+        },
+      }
+
+      // Test canOfferDouble - should return false due to Crawford rule
+      const canDouble = Game.canOfferDouble(gameInRolling, gameInRolling.activePlayer!)
+
+      expect(canDouble).toBe(false)
+      expect(gameInRolling.rules?.useCrawfordRule).toBe(true)
+      expect(gameInRolling.matchInfo?.isCrawford).toBe(true)
+    })
+
+    it('should allow doubling when Crawford rule is enabled but isCrawford is false', () => {
+      const game = Game.createNewGame(
+        { userId: 'player1', isRobot: false },
+        { userId: 'player2', isRobot: false }
+      )
+
+      const rolledForStart = Game.rollForStart(game)
+      const rolled = Game.roll(rolledForStart)
+
+      const gameInRolling: BackgammonGame = {
+        ...rolled,
+        stateKind: 'rolling',
+        rules: {
+          useCrawfordRule: true,
+        },
+        matchInfo: {
+          matchId: 'test-match-1',
+          gameNumber: 4,
+          matchLength: 5,
+          matchScore: { white: 3, black: 3 },
+          isCrawford: false, // Not a Crawford game
+        },
+      }
+
+      // Test canOfferDouble - should return true (Crawford rule enabled but not Crawford game)
+      const canDouble = Game.canOfferDouble(gameInRolling, gameInRolling.activePlayer!)
+
+      expect(canDouble).toBe(true)
+      expect(gameInRolling.rules?.useCrawfordRule).toBe(true)
+      expect(gameInRolling.matchInfo?.isCrawford).toBe(false)
+    })
+
+    it('should allow doubling when Crawford rule is disabled', () => {
+      const game = Game.createNewGame(
+        { userId: 'player1', isRobot: false },
+        { userId: 'player2', isRobot: false }
+      )
+
+      const rolledForStart = Game.rollForStart(game)
+      const rolled = Game.roll(rolledForStart)
+
+      const gameInRolling: BackgammonGame = {
+        ...rolled,
+        stateKind: 'rolling',
+        rules: {
+          useCrawfordRule: false,
+        },
+        matchInfo: {
+          matchId: 'test-match-1',
+          gameNumber: 3,
+          matchLength: 5,
+          matchScore: { white: 3, black: 2 },
+          isCrawford: true, // This should be ignored when rule is disabled
+        },
+      }
+
+      // Should allow doubling since Crawford rule is disabled
+      const canDouble = Game.canOfferDouble(gameInRolling, gameInRolling.activePlayer!)
+      expect(canDouble).toBe(true)
+    })
+  })
+
+  describe('Jacoby Rule - Game Creation with Rules', () => {
+    it('should create game with Jacoby rule enabled when passed in options', () => {
+      const game = Game.createNewGame(
+        { userId: 'player1', isRobot: false },
+        { userId: 'player2', isRobot: false },
+        {
+          rules: {
+            useJacobyRule: true,
+          },
+        }
+      )
+
+      expect(game.rules?.useJacobyRule).toBe(true)
+    })
+
+    it('should create game with Crawford rule enabled when passed in options', () => {
+      const game = Game.createNewGame(
+        { userId: 'player1', isRobot: false },
+        { userId: 'player2', isRobot: false },
+        {
+          rules: {
+            useCrawfordRule: true,
+          },
+        }
+      )
+
+      expect(game.rules?.useCrawfordRule).toBe(true)
+    })
+
+    it('should create game with multiple rules enabled', () => {
+      const game = Game.createNewGame(
+        { userId: 'player1', isRobot: false },
+        { userId: 'player2', isRobot: false },
+        {
+          rules: {
+            useCrawfordRule: true,
+            useJacobyRule: true,
+            useBeaverRule: true,
+          },
+        }
+      )
+
+      expect(game.rules?.useCrawfordRule).toBe(true)
+      expect(game.rules?.useJacobyRule).toBe(true)
+      expect(game.rules?.useBeaverRule).toBe(true)
+    })
+
+    it('should create game with no rules when options not provided', () => {
+      const game = Game.createNewGame(
+        { userId: 'player1', isRobot: false },
+        { userId: 'player2', isRobot: false }
+      )
+
+      // Rules should be empty object or undefined
+      expect(game.rules?.useCrawfordRule).toBeUndefined()
+      expect(game.rules?.useJacobyRule).toBeUndefined()
+    })
+  })
+
+  describe('refuseDouble scoring', () => {
+    it('should return winType simple and correct pointsWon when double is refused', () => {
+      const game = Game.createNewGame(
+        { userId: 'player1', isRobot: false },
+        { userId: 'player2', isRobot: false }
+      )
+
+      const rolledForStart = Game.rollForStart(game)
+
+      // Get to rolling state
+      const rollingGame: BackgammonGame = {
+        ...rolledForStart,
+        stateKind: 'rolling',
+        activePlayer: {
+          ...rolledForStart.activePlayer,
+          stateKind: 'rolling',
+        },
+        inactivePlayer: {
+          ...rolledForStart.inactivePlayer,
+          stateKind: 'inactive',
+        },
+      } as any
+
+      // Offer a double
+      const doubledGame = Game.double(rollingGame as any)
+
+      // The non-offering player refuses
+      const refusingPlayer = doubledGame.players.find(
+        p => p.id !== doubledGame.cube.offeredBy?.id
+      )!
+
+      const completedGame = Game.refuseDouble(doubledGame, refusingPlayer as any)
+
+      expect(completedGame.stateKind).toBe('completed')
+      expect((completedGame as any).winType).toBe('simple')
+      // When refusing first double from centered cube, points = 1
+      expect((completedGame as any).pointsWon).toBe(1)
+    })
+  })
+})

--- a/src/Game/index.ts
+++ b/src/Game/index.ts
@@ -79,7 +79,17 @@ export class Game {
 
   public static createNewGame = function createNewGame(
     player1: { userId: string; isRobot: boolean },
-    player2: { userId: string; isRobot: boolean }
+    player2: { userId: string; isRobot: boolean },
+    options?: {
+      rules?: {
+        useCrawfordRule?: boolean
+        useJacobyRule?: boolean
+        useBeaverRule?: boolean
+        useRaccoonRule?: boolean
+        useMurphyRule?: boolean
+        useHollandRule?: boolean
+      }
+    }
   ): BackgammonGameRollingForStart {
     let blackDirection: BackgammonMoveDirection
     let whiteDirection: BackgammonMoveDirection
@@ -130,6 +140,11 @@ export class Game {
       ...game,
       players:
         playersWithCorrectPipCounts as BackgammonPlayersRollingForStartTuple,
+      // Apply game rules if provided
+      rules: {
+        ...game.rules,
+        ...options?.rules,
+      },
     }
 
     return game
@@ -1145,6 +1160,62 @@ export class Game {
         pipCount: 0, // Winner has 0 pip count
       } as BackgammonPlayerWinner
 
+      // Find the loser for scoring calculation
+      const loser = updatedPlayers.find((p) => p.id !== winner.id)!
+      const loserDirection = loser.direction
+
+      // Calculate win type based on loser's checker positions
+      const loserCheckersOff = board.off[loserDirection]?.checkers?.length ?? 0
+      const loserCheckersOnBar = board.bar[loserDirection]?.checkers?.length ?? 0
+
+      // Check if loser has checkers in winner's home board (positions 1-6 from winner's perspective)
+      const winnerDirection = winner.direction
+      const loserCheckersInWinnerHome = board.points.some((point) => {
+        const positionFromWinnerPerspective = point.position[winnerDirection]
+        return (
+          positionFromWinnerPerspective >= 1 &&
+          positionFromWinnerPerspective <= 6 &&
+          point.checkers.some((c) => c.color === loser.color)
+        )
+      })
+
+      // Determine base win type
+      let winType: 'simple' | 'gammon' | 'backgammon' = 'simple'
+      let baseMultiplier = 1
+
+      if (loserCheckersOff === 0) {
+        // Loser has no checkers off - at minimum a gammon
+        if (loserCheckersOnBar > 0 || loserCheckersInWinnerHome) {
+          // Backgammon: loser has checkers on bar OR in winner's home board
+          winType = 'backgammon'
+          baseMultiplier = 3
+        } else {
+          // Gammon: loser just has no checkers off
+          winType = 'gammon'
+          baseMultiplier = 2
+        }
+      }
+
+      // Jacoby rule: In money games, gammons/backgammons only count if cube was turned
+      // Cube is considered "never turned" if value is undefined (centered)
+      const cubeValue = game.cube?.value
+      const cubeWasTurned = cubeValue !== undefined
+      if (game.rules?.useJacobyRule && !cubeWasTurned && winType !== 'simple') {
+        logger.info(
+          `📜 [Game] Jacoby rule applied: ${winType} reduced to simple (cube never turned)`
+        )
+        winType = 'simple'
+        baseMultiplier = 1
+      }
+
+      // Calculate total points: base multiplier * cube value (cube defaults to 1 if not turned)
+      const cubeMultiplier = cubeValue ?? 1
+      const pointsWon = baseMultiplier * cubeMultiplier
+
+      logger.info(
+        `🏆 [Game] Win type: ${winType}, Points won: ${pointsWon} (${baseMultiplier}x base * ${cubeMultiplier} cube)`
+      )
+
       // Update players array to include the winner with correct state
       const finalPlayers = updatedPlayers.map((p) =>
         p.id === winner.id ? winner : p
@@ -1156,6 +1227,8 @@ export class Game {
         ...game,
         stateKind: 'completed',
         winner: winner.id,
+        winType,
+        pointsWon,
         board,
         activePlayer: winner,
         activePlay: updatedActivePlay,
@@ -1719,6 +1792,12 @@ export class Game {
     game: BackgammonGame,
     player: BackgammonPlayerActive
   ): boolean {
+    // Crawford rule: No doubling allowed during the Crawford game
+    // The Crawford game is the first game after a player reaches match point - 1
+    if (game.rules?.useCrawfordRule && game.matchInfo?.isCrawford) {
+      return false
+    }
+
     // Allow doubling from rolling state only (before rolling dice)
     // Only if cube is centered (no owner) OR the player owns the cube
     // and cube is not maxxed or already offered
@@ -1901,7 +1980,7 @@ export class Game {
   ): BackgammonGame {
     if (!Game.canRefuseDouble(game, player))
       throw new Error('Cannot refuse double')
-    // The refusing player loses at the current cube value
+    // The refusing player loses at the current cube value (before the proposed double)
     // The offering player is the winner
     const offeringPlayer = game.cube.offeredBy!
     const winner = {
@@ -1914,10 +1993,21 @@ export class Game {
       p.id === winner.id ? winner : p
     ) as BackgammonPlayers
 
+    // When refusing a double, winner gets the cube value BEFORE the proposed double
+    // If cube was centered (value undefined), use 1. Otherwise use current value / 2 (pre-double value)
+    const currentCubeValue = game.cube?.value
+    const pointsWon = currentCubeValue !== undefined ? currentCubeValue / 2 : 1
+
+    logger.info(
+      `🏆 [Game] Double refused - Winner: ${winner.id}, Points won: ${pointsWon}`
+    )
+
     return Game.incrementStateVersion({
       ...game,
       stateKind: 'completed',
       winner: winner.id,
+      winType: 'simple', // Cube drops are always simple wins
+      pointsWon,
       players: updatedPlayers,
     } as BackgammonGameCompleted)
   }


### PR DESCRIPTION
## Summary
- **Crawford Rule**: canOfferDouble() blocks doubling when useCrawfordRule and isCrawford are true
- **Jacoby Rule**: Game completion reduces gammons/backgammons to simple wins when useJacobyRule is true and cube was never turned
- **Game Creation**: createNewGame() now accepts optional rules parameter
- **Scoring**: Game completion calculates and stores winType and pointsWon

## Tests
8 unit tests covering:
- Crawford rule blocks/allows doubling based on isCrawford flag
- Game creation with various rule configurations
- refuseDouble returns correct winType and pointsWon

## Related
Part of nodots/nodots-backgammon#246 - Gap Analysis implementation (Phase 1: Core Rules)

## Test plan
- [ ] `npm test -- --testPathPattern="crawford-jacoby"` passes (8 tests)
- [ ] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)