### PR TITLE
feat: implement Match Equity Table module with Kazaross-XG2 data

### DIFF
--- a/src/MET/__tests__/met.test.ts
+++ b/src/MET/__tests__/met.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from '@jest/globals'
+import {
+  DEFAULT_MET,
+  getMatchEquity,
+  getTakePoint,
+  getDoublePoint,
+  getGammonValues,
+  getMatchScoreContext,
+  analyzeCubeDecision,
+} from '../index'
+
+describe('Match Equity Table', () => {
+  describe('DEFAULT_MET', () => {
+    it('should have correct metadata', () => {
+      expect(DEFAULT_MET.name).toBe('Kazaross XG2 25 point MET')
+      expect(DEFAULT_MET.maxLength).toBe(25)
+      expect(DEFAULT_MET.preCrawford.length).toBe(25)
+      expect(DEFAULT_MET.postCrawford.length).toBe(25)
+    })
+
+    it('should have symmetric 50% equity at equal scores', () => {
+      // At any equal score, equity should be 50%
+      expect(DEFAULT_MET.preCrawford[0][0]).toBe(0.5) // 1-away vs 1-away
+      expect(DEFAULT_MET.preCrawford[4][4]).toBe(0.5) // 5-away vs 5-away
+      expect(DEFAULT_MET.preCrawford[9][9]).toBe(0.5) // 10-away vs 10-away
+    })
+  })
+
+  describe('getMatchEquity', () => {
+    it('should return 50% for equal scores', () => {
+      expect(getMatchEquity(5, 5)).toBeCloseTo(0.5, 4)
+      expect(getMatchEquity(1, 1)).toBeCloseTo(0.5, 4)
+    })
+
+    it('should return higher equity when player is ahead', () => {
+      // 1-away vs 5-away should be > 50%
+      const equity = getMatchEquity(1, 5)
+      expect(equity).toBeGreaterThan(0.5)
+      expect(equity).toBeCloseTo(0.84179, 4)
+    })
+
+    it('should return lower equity when player is behind', () => {
+      // 5-away vs 1-away should be < 50%
+      const equity = getMatchEquity(5, 1)
+      expect(equity).toBeLessThan(0.5)
+      expect(equity).toBeCloseTo(0.15821, 4)
+    })
+
+    it('should use post-Crawford table when appropriate', () => {
+      // Post-Crawford: player at match point (1-away) vs opponent 3-away
+      const equity = getMatchEquity(1, 3, false, true)
+      expect(equity).toBeCloseTo(0.32264, 4)
+    })
+  })
+
+  describe('getMatchScoreContext', () => {
+    it('should detect Crawford game correctly', () => {
+      // Crawford: one player at match point - 1, other not
+      const context1 = getMatchScoreContext(4, 0, 5) // Player 1-away, opp 5-away
+      expect(context1.isCrawford).toBe(true)
+      expect(context1.isPostCrawford).toBe(false)
+
+      const context2 = getMatchScoreContext(0, 4, 5) // Player 5-away, opp 1-away
+      expect(context2.isCrawford).toBe(true)
+    })
+
+    it('should calculate away scores correctly', () => {
+      const context = getMatchScoreContext(3, 2, 7)
+      expect(context.playerAway).toBe(4) // 7 - 3
+      expect(context.opponentAway).toBe(5) // 7 - 2
+      expect(context.matchLength).toBe(7)
+    })
+  })
+
+  describe('getTakePoint', () => {
+    it('should return approximately 25% for money game equivalent', () => {
+      // At equal scores with cube at 1, take point should be around 20-25%
+      const takePoint = getTakePoint(5, 5, 1)
+      expect(takePoint).toBeGreaterThan(0.18)
+      expect(takePoint).toBeLessThan(0.30)
+    })
+
+    it('should increase when trailing in match', () => {
+      // When trailing, take point goes up (more to lose)
+      const equalTake = getTakePoint(5, 5, 1)
+      const trailingTake = getTakePoint(3, 7, 1) // 3-away vs 7-away (trailing)
+      expect(trailingTake).toBeGreaterThan(equalTake)
+    })
+  })
+
+  describe('getDoublePoint', () => {
+    it('should return reasonable double point', () => {
+      const doublePoint = getDoublePoint(5, 5, 1)
+      expect(doublePoint).toBeGreaterThan(0.5) // Need to be favorite to double
+      expect(doublePoint).toBeLessThan(0.85) // But not too high
+    })
+  })
+
+  describe('getGammonValues', () => {
+    it('should return positive gammon values for player', () => {
+      const values = getGammonValues(5, 5, 1, false)
+      expect(values.playerGammonValue).toBeGreaterThan(0)
+      expect(values.playerBackgammonValue).toBeGreaterThan(values.playerGammonValue)
+    })
+
+    it('should have zero gammon value when gammon is useless', () => {
+      // When player needs 1 point, gammon doesn't help
+      const values = getGammonValues(1, 5, 1, false)
+      expect(values.playerGammonValue).toBe(0)
+      expect(values.playerBackgammonValue).toBe(0)
+    })
+  })
+
+  describe('analyzeCubeDecision', () => {
+    it('should recommend taking with good winning chances', () => {
+      const analysis = analyzeCubeDecision(
+        5, // playerAway
+        5, // opponentAway
+        0.4, // 40% chance to win - above typical take point
+        0, // gammonRate
+        0, // backgammonRate
+        1, // cubeValue
+        false // isCrawford
+      )
+      expect(analysis.shouldPass).toBe(false)
+    })
+
+    it('should recommend passing with poor winning chances', () => {
+      const analysis = analyzeCubeDecision(
+        5, // playerAway
+        5, // opponentAway
+        0.1, // 10% chance to win - below take point
+        0, // gammonRate
+        0, // backgammonRate
+        1, // cubeValue
+        false // isCrawford
+      )
+      expect(analysis.shouldPass).toBe(true)
+    })
+
+    it('should not recommend doubling in Crawford game', () => {
+      const analysis = analyzeCubeDecision(
+        1, // playerAway (at match point)
+        3, // opponentAway
+        0.8, // 80% chance to win
+        0,
+        0,
+        1,
+        true // isCrawford
+      )
+      expect(analysis.shouldDouble).toBe(false)
+    })
+  })
+})

--- a/src/MET/index.ts
+++ b/src/MET/index.ts
@@ -1,0 +1,381 @@
+/**
+ * Match Equity Table (MET) Module
+ *
+ * Provides match equity calculations for cube decisions in match play.
+ * Uses the Kazaross-XG2 MET (generated using XG rollouts to 9pts,
+ * GNUbg Supremo full rollouts to 15 points, extended to 25pts).
+ */
+
+import type {
+  MatchEquityTable,
+  MatchScoreContext,
+  CubeDecisionAnalysis,
+  GammonValues,
+} from '@nodots-llc/backgammon-types'
+
+/**
+ * Kazaross-XG2 25-point Match Equity Table
+ * Pre-Crawford table: preCrawford[i][j] = equity when you need (i+1) and opponent needs (j+1)
+ */
+const KAZAROSS_XG2_PRE_CRAWFORD: number[][] = [
+  [0.50000, 0.67736, 0.75076, 0.81436, 0.84179, 0.88731, 0.90724, 0.93250, 0.94402, 0.959275, 0.966442, 0.975534, 0.979845, 0.985273, 0.987893, 0.99114, 0.99273, 0.99467, 0.99563, 0.99679, 0.99737, 0.99807, 0.99842, 0.99884, 0.99905],
+  [0.32264, 0.50000, 0.59947, 0.66870, 0.74359, 0.79940, 0.84225, 0.87539, 0.90197, 0.923034, 0.939311, 0.952470, 0.962495, 0.970701, 0.976887, 0.98196, 0.98580, 0.98893, 0.99129, 0.99322, 0.99466, 0.99585, 0.99675, 0.99746, 0.99802],
+  [0.24924, 0.40053, 0.50000, 0.57150, 0.64795, 0.71123, 0.76209, 0.80468, 0.84017, 0.870638, 0.894417, 0.914831, 0.930702, 0.944426, 0.954931, 0.96399, 0.97093, 0.97687, 0.98139, 0.98522, 0.98814, 0.99062, 0.99248, 0.99407, 0.99527],
+  [0.18564, 0.33130, 0.42850, 0.50000, 0.57732, 0.64285, 0.69924, 0.74577, 0.78799, 0.824059, 0.853955, 0.879141, 0.900233, 0.918040, 0.932657, 0.94495, 0.95499, 0.96341, 0.97021, 0.97589, 0.98044, 0.98422, 0.98726, 0.98975, 0.99174],
+  [0.15821, 0.25641, 0.35205, 0.42268, 0.50000, 0.56635, 0.62638, 0.67786, 0.72540, 0.767055, 0.802732, 0.833654, 0.859934, 0.882866, 0.902013, 0.91847, 0.93223, 0.94397, 0.95367, 0.96189, 0.96864, 0.97432, 0.97896, 0.98283, 0.98600],
+  [0.11269, 0.20060, 0.28877, 0.35715, 0.43365, 0.50000, 0.56261, 0.61636, 0.66787, 0.713057, 0.753427, 0.788634, 0.819569, 0.846648, 0.869999, 0.89021, 0.90756, 0.92246, 0.93508, 0.94583, 0.95488, 0.96254, 0.96894, 0.97432, 0.97879],
+  [0.09276, 0.15775, 0.23791, 0.30076, 0.37362, 0.43739, 0.50000, 0.55480, 0.60854, 0.656283, 0.700209, 0.739054, 0.774121, 0.805203, 0.832566, 0.85659, 0.87761, 0.89591, 0.91171, 0.92535, 0.93702, 0.94703, 0.95553, 0.96276, 0.96887],
+  [0.06750, 0.12461, 0.19532, 0.25423, 0.32214, 0.38364, 0.44520, 0.50000, 0.55442, 0.603718, 0.649899, 0.691356, 0.729447, 0.763593, 0.794397, 0.82158, 0.84578, 0.86714, 0.88589, 0.90230, 0.91658, 0.92898, 0.93968, 0.94891, 0.95682],
+  [0.05598, 0.09803, 0.15983, 0.21201, 0.27460, 0.33213, 0.39146, 0.44558, 0.50000, 0.550196, 0.597926, 0.641481, 0.682119, 0.718927, 0.752814, 0.78301, 0.81037, 0.83483, 0.85662, 0.87591, 0.89294, 0.90791, 0.92098, 0.93240, 0.94230],
+  [0.040725, 0.076966, 0.129362, 0.175941, 0.232945, 0.286943, 0.343717, 0.396282, 0.449804, 0.500000, 0.548547, 0.593459, 0.635880, 0.674830, 0.711113, 0.74371, 0.77375, 0.80093, 0.82543, 0.84741, 0.86703, 0.88448, 0.89991, 0.91353, 0.92550],
+  [0.033558, 0.060689, 0.105583, 0.146045, 0.197268, 0.246573, 0.299791, 0.350101, 0.402074, 0.451453, 0.500000, 0.545552, 0.589242, 0.629736, 0.667927, 0.70303, 0.73530, 0.76494, 0.79198, 0.81648, 0.83862, 0.85849, 0.87629, 0.89214, 0.90622],
+  [0.024466, 0.047530, 0.085169, 0.120859, 0.166346, 0.211366, 0.260946, 0.308644, 0.358519, 0.406541, 0.454448, 0.500000, 0.544068, 0.585701, 0.625259, 0.66178, 0.69610, 0.72778, 0.75703, 0.78381, 0.80826, 0.83044, 0.85051, 0.86856, 0.88476],
+  [0.020155, 0.037505, 0.069298, 0.099767, 0.140066, 0.180431, 0.225879, 0.270553, 0.317881, 0.364120, 0.410758, 0.455932, 0.500000, 0.541943, 0.582545, 0.62036, 0.65619, 0.68966, 0.72081, 0.74963, 0.77619, 0.80054, 0.82276, 0.84295, 0.86123],
+  [0.014727, 0.029299, 0.055574, 0.081960, 0.117134, 0.153352, 0.194797, 0.236407, 0.281073, 0.325170, 0.370264, 0.414299, 0.458057, 0.500000, 0.540750, 0.57942, 0.61634, 0.65117, 0.68391, 0.71448, 0.74290, 0.76917, 0.79339, 0.81559, 0.83586],
+  [0.012107, 0.023113, 0.045069, 0.067343, 0.097987, 0.130001, 0.167434, 0.205603, 0.247186, 0.288887, 0.332073, 0.374741, 0.417455, 0.459250, 0.500000, 0.53916, 0.57679, 0.61261, 0.64659, 0.67859, 0.70862, 0.73664, 0.76265, 0.78669, 0.80883],
+  [0.00886, 0.01804, 0.03601, 0.05505, 0.08153, 0.10979, 0.14341, 0.17842, 0.21699, 0.25629, 0.29697, 0.33822, 0.37964, 0.42058, 0.46084, 0.50000, 0.53796, 0.57441, 0.60929, 0.64241, 0.67376, 0.70323, 0.73084, 0.75657, 0.78046],
+  [0.00727, 0.01420, 0.02907, 0.04501, 0.06777, 0.09244, 0.12239, 0.15422, 0.18963, 0.22625, 0.26470, 0.30390, 0.34381, 0.38366, 0.42321, 0.46204, 0.50000, 0.53676, 0.57222, 0.60618, 0.63856, 0.66925, 0.69822, 0.72542, 0.75087],
+  [0.00533, 0.01107, 0.02313, 0.03659, 0.05603, 0.07754, 0.10409, 0.13286, 0.16517, 0.19907, 0.23506, 0.27222, 0.31034, 0.34883, 0.38739, 0.42559, 0.46324, 0.50000, 0.53574, 0.57023, 0.60336, 0.63501, 0.66510, 0.69356, 0.72038],
+  [0.00437, 0.00871, 0.01861, 0.02979, 0.04633, 0.06492, 0.08829, 0.11411, 0.14338, 0.17457, 0.20802, 0.24297, 0.27919, 0.31609, 0.35341, 0.39071, 0.42778, 0.46426, 0.50000, 0.53475, 0.56838, 0.60073, 0.63171, 0.66122, 0.68921],
+  [0.00321, 0.00678, 0.01478, 0.02411, 0.03811, 0.05417, 0.07465, 0.09770, 0.12409, 0.15259, 0.18352, 0.21619, 0.25037, 0.28552, 0.32141, 0.35759, 0.39382, 0.42977, 0.46525, 0.50000, 0.53387, 0.56667, 0.59830, 0.62864, 0.65760],
+  [0.00263, 0.00534, 0.01186, 0.01956, 0.03136, 0.04512, 0.06298, 0.08342, 0.10706, 0.13297, 0.16138, 0.19174, 0.22381, 0.25710, 0.29138, 0.32624, 0.36144, 0.39664, 0.43162, 0.46613, 0.50000, 0.53303, 0.56508, 0.59603, 0.62576],
+  [0.00193, 0.00415, 0.00938, 0.01578, 0.02568, 0.03746, 0.05297, 0.07102, 0.09209, 0.11552, 0.14151, 0.16956, 0.19946, 0.23083, 0.26336, 0.29677, 0.33075, 0.36499, 0.39927, 0.43333, 0.46697, 0.50000, 0.53226, 0.56360, 0.59391],
+  [0.00158, 0.00325, 0.00752, 0.01274, 0.02104, 0.03106, 0.04447, 0.06032, 0.07902, 0.10009, 0.12371, 0.14949, 0.17724, 0.20661, 0.23735, 0.26916, 0.30178, 0.33490, 0.36829, 0.40170, 0.43492, 0.46774, 0.50000, 0.53153, 0.56221],
+  [0.00116, 0.00254, 0.00593, 0.01025, 0.01717, 0.02568, 0.03724, 0.05109, 0.06760, 0.08647, 0.10786, 0.13144, 0.15705, 0.18441, 0.21331, 0.24343, 0.27458, 0.30644, 0.33878, 0.37136, 0.40397, 0.43640, 0.46847, 0.50000, 0.53086],
+  [0.00095, 0.00198, 0.00473, 0.00826, 0.01400, 0.02121, 0.03113, 0.04318, 0.05770, 0.07450, 0.09378, 0.11524, 0.13877, 0.16414, 0.19117, 0.21954, 0.24913, 0.27962, 0.31079, 0.34240, 0.37424, 0.40609, 0.43779, 0.46914, 0.50000],
+]
+
+/**
+ * Post-Crawford equity table
+ * postCrawford[i] = equity when you need 1 (at match point) and opponent needs (i+1)
+ */
+const KAZAROSS_XG2_POST_CRAWFORD: number[] = [
+  0.500000, 0.48803, 0.32264, 0.31002, 0.19012, 0.18072, 0.11559, 0.10906,
+  0.06953, 0.065161, 0.042069, 0.039060, 0.025371, 0.023428, 0.015304,
+  0.014050, 0.009240, 0.008420, 0.005560, 0.005050, 0.003360, 0.003030,
+  0.002030, 0.001820, 0.001230,
+]
+
+/**
+ * The default Match Equity Table (Kazaross-XG2)
+ */
+export const DEFAULT_MET: MatchEquityTable = {
+  name: 'Kazaross XG2 25 point MET',
+  description:
+    'Generated using XG rollouts to 9pts, GNUbg Supremo full rollouts to 15 points. Extended to 25pts by projecting take points.',
+  maxLength: 25,
+  preCrawford: KAZAROSS_XG2_PRE_CRAWFORD,
+  postCrawford: KAZAROSS_XG2_POST_CRAWFORD,
+}
+
+/**
+ * Get match equity from the MET
+ *
+ * @param playerAway - Points the player needs to win
+ * @param opponentAway - Points the opponent needs to win
+ * @param isCrawford - Whether this is a Crawford game
+ * @param isPostCrawford - Whether this is a post-Crawford game
+ * @param met - The MET to use (defaults to Kazaross-XG2)
+ * @returns Match winning probability for the player
+ */
+export function getMatchEquity(
+  playerAway: number,
+  opponentAway: number,
+  isCrawford: boolean = false,
+  isPostCrawford: boolean = false,
+  met: MatchEquityTable = DEFAULT_MET
+): number {
+  // Clamp to valid range
+  const pAway = Math.max(1, Math.min(playerAway, met.maxLength))
+  const oAway = Math.max(1, Math.min(opponentAway, met.maxLength))
+
+  // If either player has won
+  if (pAway <= 0) return 1.0
+  if (oAway <= 0) return 0.0
+
+  // Post-Crawford: player at match point (needs 1)
+  if (isPostCrawford && pAway === 1) {
+    return met.postCrawford[oAway - 1]
+  }
+
+  // Post-Crawford: opponent at match point (needs 1)
+  if (isPostCrawford && oAway === 1) {
+    return 1.0 - met.postCrawford[pAway - 1]
+  }
+
+  // Pre-Crawford or Crawford game
+  return met.preCrawford[pAway - 1][oAway - 1]
+}
+
+/**
+ * Get the match score context from current game state
+ */
+export function getMatchScoreContext(
+  playerScore: number,
+  opponentScore: number,
+  matchLength: number
+): MatchScoreContext {
+  const playerAway = matchLength - playerScore
+  const opponentAway = matchLength - opponentScore
+
+  // Crawford game is the first game after a player reaches match point - 1
+  // It's Crawford if exactly one player needs 1 point and no one has used Crawford yet
+  const isCrawford =
+    (playerAway === 1 && opponentAway > 1) ||
+    (opponentAway === 1 && playerAway > 1)
+
+  // Post-Crawford is after the Crawford game has been played
+  // For simplicity, we assume if someone is at match point and it's not Crawford, it's post-Crawford
+  const isPostCrawford =
+    (playerAway === 1 || opponentAway === 1) && !isCrawford
+
+  return {
+    playerAway,
+    opponentAway,
+    matchLength,
+    isCrawford,
+    isPostCrawford,
+  }
+}
+
+/**
+ * Calculate gammon and backgammon values at a given score
+ *
+ * @param playerAway - Points the player needs
+ * @param opponentAway - Points the opponent needs
+ * @param cubeValue - Current cube value
+ * @param isCrawford - Whether this is a Crawford game
+ * @param met - The MET to use
+ * @returns Gammon values for both players
+ */
+export function getGammonValues(
+  playerAway: number,
+  opponentAway: number,
+  cubeValue: number = 1,
+  isCrawford: boolean = false,
+  met: MatchEquityTable = DEFAULT_MET
+): GammonValues {
+  const currentEquity = getMatchEquity(playerAway, opponentAway, isCrawford, false, met)
+
+  // Equity after winning a single game
+  const playerWinSingle = getMatchEquity(
+    Math.max(0, playerAway - cubeValue),
+    opponentAway,
+    false,
+    false,
+    met
+  )
+
+  // Equity after winning a gammon
+  const playerWinGammon = getMatchEquity(
+    Math.max(0, playerAway - 2 * cubeValue),
+    opponentAway,
+    false,
+    false,
+    met
+  )
+
+  // Equity after winning a backgammon
+  const playerWinBackgammon = getMatchEquity(
+    Math.max(0, playerAway - 3 * cubeValue),
+    opponentAway,
+    false,
+    false,
+    met
+  )
+
+  // Opponent wins
+  const opponentWinSingle = getMatchEquity(
+    playerAway,
+    Math.max(0, opponentAway - cubeValue),
+    false,
+    false,
+    met
+  )
+  const opponentWinGammon = getMatchEquity(
+    playerAway,
+    Math.max(0, opponentAway - 2 * cubeValue),
+    false,
+    false,
+    met
+  )
+  const opponentWinBackgammon = getMatchEquity(
+    playerAway,
+    Math.max(0, opponentAway - 3 * cubeValue),
+    false,
+    false,
+    met
+  )
+
+  // Gammon value = extra equity from gammon vs single
+  const playerGammonValue = playerWinGammon - playerWinSingle
+  const playerBackgammonValue = playerWinBackgammon - playerWinSingle
+
+  const opponentGammonValue = opponentWinSingle - opponentWinGammon
+  const opponentBackgammonValue = opponentWinSingle - opponentWinBackgammon
+
+  return {
+    playerGammonValue,
+    opponentGammonValue,
+    playerBackgammonValue,
+    opponentBackgammonValue,
+  }
+}
+
+/**
+ * Calculate the take point (minimum game winning probability to take a double)
+ *
+ * In money play, the take point is 25% (you need to win 1 game out of 4 to break even).
+ * In match play, it depends on the score and cube value.
+ *
+ * @param playerAway - Points the player needs
+ * @param opponentAway - Points the opponent needs
+ * @param cubeValue - Current cube value (before double)
+ * @param met - The MET to use
+ * @returns Minimum game winning probability to take
+ */
+export function getTakePoint(
+  playerAway: number,
+  opponentAway: number,
+  cubeValue: number = 1,
+  met: MatchEquityTable = DEFAULT_MET
+): number {
+  const newCubeValue = cubeValue * 2
+
+  // Equity if we pass (lose cubeValue points)
+  const equityIfPass = getMatchEquity(
+    playerAway,
+    Math.max(0, opponentAway - cubeValue),
+    false,
+    false,
+    met
+  )
+
+  // Equity if we take and lose (lose newCubeValue points)
+  const equityIfTakeLose = getMatchEquity(
+    playerAway,
+    Math.max(0, opponentAway - newCubeValue),
+    false,
+    false,
+    met
+  )
+
+  // Equity if we take and win (win newCubeValue points)
+  const equityIfTakeWin = getMatchEquity(
+    Math.max(0, playerAway - newCubeValue),
+    opponentAway,
+    false,
+    false,
+    met
+  )
+
+  // Take point: P * equityIfTakeWin + (1-P) * equityIfTakeLose >= equityIfPass
+  // Solving for P: P >= (equityIfPass - equityIfTakeLose) / (equityIfTakeWin - equityIfTakeLose)
+  const denominator = equityIfTakeWin - equityIfTakeLose
+  if (denominator <= 0) {
+    return 0.5 // Edge case: no difference
+  }
+
+  const takePoint = (equityIfPass - equityIfTakeLose) / denominator
+  return Math.max(0, Math.min(1, takePoint))
+}
+
+/**
+ * Calculate the double point (minimum game winning probability to offer a double)
+ *
+ * @param playerAway - Points the player needs
+ * @param opponentAway - Points the opponent needs
+ * @param cubeValue - Current cube value
+ * @param met - The MET to use
+ * @returns Minimum game winning probability to double
+ */
+export function getDoublePoint(
+  playerAway: number,
+  opponentAway: number,
+  cubeValue: number = 1,
+  met: MatchEquityTable = DEFAULT_MET
+): number {
+  // The double point is typically around the take point
+  // For a proper calculation, we need to consider the recube vig
+  // For simplicity, we use the take point as an approximation
+  // A more sophisticated calculation would account for whether opponent can recube
+
+  const takePoint = getTakePoint(opponentAway, playerAway, cubeValue, met)
+
+  // The double point is typically slightly below the opponent's take point
+  // to account for the recube vig (when opponent can recube, we need to be more cautious)
+  // A common approximation is: doublePoint = 1 - 2 * (1 - takePoint)
+  // This gives us the point where we're indifferent between doubling and not doubling
+  return 1 - takePoint
+}
+
+/**
+ * Analyze a cube decision at a given score
+ *
+ * @param playerAway - Points the player needs
+ * @param opponentAway - Points the opponent needs
+ * @param gameWinningProb - Player's probability of winning the current game
+ * @param gammonRate - Probability of winning a gammon (given we win)
+ * @param backgammonRate - Probability of winning a backgammon (given we win a gammon)
+ * @param cubeValue - Current cube value
+ * @param isCrawford - Whether this is a Crawford game
+ * @param met - The MET to use
+ * @returns Cube decision analysis
+ */
+export function analyzeCubeDecision(
+  playerAway: number,
+  opponentAway: number,
+  gameWinningProb: number,
+  gammonRate: number = 0,
+  backgammonRate: number = 0,
+  cubeValue: number = 1,
+  isCrawford: boolean = false,
+  met: MatchEquityTable = DEFAULT_MET
+): CubeDecisionAnalysis {
+  const matchEquity = getMatchEquity(playerAway, opponentAway, isCrawford, false, met)
+  const takePoint = getTakePoint(playerAway, opponentAway, cubeValue, met)
+  const doublePoint = getDoublePoint(playerAway, opponentAway, cubeValue, met)
+  const gammonValues = getGammonValues(playerAway, opponentAway, cubeValue, isCrawford, met)
+
+  // Equity if we pass a double
+  const equityIfPass = getMatchEquity(
+    playerAway,
+    Math.max(0, opponentAway - cubeValue),
+    false,
+    false,
+    met
+  )
+
+  // Equity if we take (simplified - doesn't account for gammons perfectly)
+  const newCubeValue = cubeValue * 2
+  const equityIfTakeWin = getMatchEquity(
+    Math.max(0, playerAway - newCubeValue),
+    opponentAway,
+    false,
+    false,
+    met
+  )
+  const equityIfTakeLose = getMatchEquity(
+    playerAway,
+    Math.max(0, opponentAway - newCubeValue),
+    false,
+    false,
+    met
+  )
+  const equityIfTake =
+    gameWinningProb * equityIfTakeWin + (1 - gameWinningProb) * equityIfTakeLose
+
+  return {
+    matchEquity,
+    equityIfPass,
+    equityIfTake,
+    takePoint,
+    doublePoint,
+    gammonPrice: gammonValues.playerGammonValue,
+    backgammonPrice: gammonValues.playerBackgammonValue,
+    shouldPass: gameWinningProb < takePoint,
+    shouldDouble: gameWinningProb >= doublePoint && !isCrawford,
+  }
+}
+
+export { KAZAROSS_XG2_PRE_CRAWFORD, KAZAROSS_XG2_POST_CRAWFORD }

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,3 +66,4 @@ export {
 export type * from '@nodots-llc/backgammon-types'
 export { GameEventEmitter } from './events/GameEventEmitter'
 export * from './XG' // Re-enabled for Issue #213 fix - XG import with proper board state tracking
+export * from './MET'


### PR DESCRIPTION
## Summary
- Add Kazaross-XG2 25-point MET (pre-Crawford and post-Crawford tables)
- Implement getMatchEquity() for match winning probability lookup
- Implement getTakePoint() and getDoublePoint() for cube decisions
- Implement getGammonValues() for gammon/backgammon value calculations
- Implement getMatchScoreContext() for determining Crawford status
- Implement analyzeCubeDecision() for comprehensive cube analysis

## Tests
16 unit tests covering all MET functions:
- DEFAULT_MET structure and symmetry
- Match equity calculations
- Crawford detection
- Take/double point calculations
- Gammon values
- Cube decision analysis

## Related
Part of nodots/nodots-backgammon#246 - Gap Analysis implementation (Phase 2: Match Equity)

## Test plan
- [ ] `npm test -- --testPathPattern="met.test"` passes (16 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)