### PR TITLE
feat(board): consolidate position-ID encoding + coordinate-frame helpers

### DIFF
--- a/src/Board/__tests__/decodePositionId.test.ts
+++ b/src/Board/__tests__/decodePositionId.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from '@jest/globals'
+import { decodePositionId, type DecodedGnuBoard } from '../decodePositionId'
+import { importFromDecoded } from '../importFromDecoded'
+import { fromPositionId } from '../fromPositionId'
+import type { OnRollContext } from '../frame'
+
+const STARTING_POSITION_ID = '4HPwATDgc/ABMA'
+
+const WHITE_CW: OnRollContext = { color: 'white', direction: 'clockwise' }
+const BLACK_CCW: OnRollContext = { color: 'black', direction: 'counterclockwise' }
+
+describe('decodePositionId', () => {
+  it('rejects invalid-length ids', () => {
+    expect(() => decodePositionId('')).toThrow()
+    expect(() => decodePositionId('too-short')).toThrow()
+    expect(() => decodePositionId('fifteen-chars-x')).toThrow()
+  })
+
+  it('returns two 25-entry arrays for a valid id', () => {
+    const decoded = decodePositionId(STARTING_POSITION_ID)
+    expect(decoded.x).toHaveLength(25)
+    expect(decoded.o).toHaveLength(25)
+  })
+
+  it('starting position puts 15 checkers on each tan array', () => {
+    const decoded = decodePositionId(STARTING_POSITION_ID)
+    const total = (arr: number[]) => arr.reduce((s, n) => s + n, 0)
+    expect(total(decoded.x)).toBe(15)
+    expect(total(decoded.o)).toBe(15)
+  })
+
+  it('starting position has checker counts at points 6, 8, 13, 24 (2/3/5/5)', () => {
+    const decoded = decodePositionId(STARTING_POSITION_ID)
+    // Both tan arrays are symmetric at the starting position.
+    for (const tan of [decoded.x, decoded.o]) {
+      expect(tan[5]).toBe(5) // point 6
+      expect(tan[7]).toBe(3) // point 8
+      expect(tan[12]).toBe(5) // point 13
+      expect(tan[23]).toBe(2) // point 24
+      expect(tan[24]).toBe(0) // no bar
+    }
+  })
+})
+
+describe('importFromDecoded', () => {
+  it('maps x onto the opponent and o onto the on-roll player', () => {
+    const decoded: DecodedGnuBoard = {
+      x: new Array(25).fill(0),
+      o: new Array(25).fill(0),
+    }
+    decoded.x[0] = 1 // opponent at opponent's point 1
+    decoded.o[0] = 1 // on-roll at on-roll's point 1
+    decoded.x[5] = 14
+    decoded.o[5] = 14
+
+    const imports = importFromDecoded(decoded, WHITE_CW)
+    // On-roll = white/clockwise: o[0] → clockwise 1, color white.
+    const onRollFirst = imports.find(
+      (cc) =>
+        typeof cc.position === 'object' &&
+        'clockwise' in cc.position &&
+        cc.position.clockwise === 1 &&
+        cc.checkers.color === 'white' &&
+        cc.checkers.qty === 1
+    )
+    expect(onRollFirst).toBeDefined()
+
+    // Opponent = black/counterclockwise: x[0] at opponent point 1 in
+    // counterclockwise direction → counterclockwise 1 = clockwise 24.
+    const opponentFirst = imports.find(
+      (cc) =>
+        typeof cc.position === 'object' &&
+        'clockwise' in cc.position &&
+        cc.position.clockwise === 24 &&
+        cc.checkers.color === 'black' &&
+        cc.checkers.qty === 1
+    )
+    expect(opponentFirst).toBeDefined()
+  })
+
+  it('flips placement when on-roll is black/counterclockwise', () => {
+    const decoded: DecodedGnuBoard = {
+      x: new Array(25).fill(0),
+      o: new Array(25).fill(0),
+    }
+    decoded.o[0] = 1 // on-roll at on-roll's point 1
+    decoded.x[0] = 1 // opponent at opponent's point 1
+    decoded.o[5] = 14
+    decoded.x[5] = 14
+
+    const imports = importFromDecoded(decoded, BLACK_CCW)
+    // On-roll = black/counterclockwise: o[0] → counterclockwise 1 = clockwise 24.
+    const onRollFirst = imports.find(
+      (cc) =>
+        typeof cc.position === 'object' &&
+        'clockwise' in cc.position &&
+        cc.position.clockwise === 24 &&
+        cc.checkers.color === 'black' &&
+        cc.checkers.qty === 1
+    )
+    expect(onRollFirst).toBeDefined()
+
+    // Opponent = white/clockwise: x[0] → clockwise 1, color white.
+    const opponentFirst = imports.find(
+      (cc) =>
+        typeof cc.position === 'object' &&
+        'clockwise' in cc.position &&
+        cc.position.clockwise === 1 &&
+        cc.checkers.color === 'white' &&
+        cc.checkers.qty === 1
+    )
+    expect(opponentFirst).toBeDefined()
+  })
+
+  it('places bar checkers on the correct direction container', () => {
+    const decoded: DecodedGnuBoard = {
+      x: new Array(25).fill(0),
+      o: new Array(25).fill(0),
+    }
+    decoded.o[24] = 2 // on-roll on bar
+    decoded.o[5] = 13
+    decoded.x[5] = 15
+
+    const imports = importFromDecoded(decoded, WHITE_CW)
+    const bar = imports.find(
+      (cc) => cc.position === 'bar' && 'direction' in cc
+    )
+    expect(bar).toBeDefined()
+    expect(bar && 'direction' in bar && bar.direction).toBe('clockwise')
+    expect(bar?.checkers.color).toBe('white')
+    expect(bar?.checkers.qty).toBe(2)
+  })
+
+  it('emits off containers when a player has borne off', () => {
+    const decoded: DecodedGnuBoard = {
+      x: new Array(25).fill(0),
+      o: new Array(25).fill(0),
+    }
+    decoded.o[5] = 10 // 10 on-roll on point 6 → 5 off
+    decoded.x[5] = 15 // opponent full on point 6
+
+    const imports = importFromDecoded(decoded, WHITE_CW)
+    const off = imports.find(
+      (cc) =>
+        cc.position === 'off' && 'direction' in cc && cc.direction === 'clockwise'
+    )
+    expect(off?.checkers.qty).toBe(5)
+    expect(off?.checkers.color).toBe('white')
+  })
+})
+
+describe('fromPositionId', () => {
+  it('produces a board with the starting layout for white-on-roll', () => {
+    const board = fromPositionId(STARTING_POSITION_ID, WHITE_CW)
+    expect(board.points).toHaveLength(24)
+
+    const cw = (i: number) => board.points.find((p) => p.position.clockwise === i)
+    // White (on-roll clockwise) has 5/3/5/2 at clockwise 6/8/13/24.
+    expect(cw(6)!.checkers.filter((c) => c.color === 'white')).toHaveLength(5)
+    expect(cw(8)!.checkers.filter((c) => c.color === 'white')).toHaveLength(3)
+    expect(cw(13)!.checkers.filter((c) => c.color === 'white')).toHaveLength(5)
+    expect(cw(24)!.checkers.filter((c) => c.color === 'white')).toHaveLength(2)
+    // Black (opponent counterclockwise) has 5/3/5/2 at counterclockwise
+    // 6/8/13/24, i.e. clockwise 19/17/12/1.
+    expect(cw(19)!.checkers.filter((c) => c.color === 'black')).toHaveLength(5)
+    expect(cw(17)!.checkers.filter((c) => c.color === 'black')).toHaveLength(3)
+    expect(cw(12)!.checkers.filter((c) => c.color === 'black')).toHaveLength(5)
+    expect(cw(1)!.checkers.filter((c) => c.color === 'black')).toHaveLength(2)
+  })
+
+  it('same id decoded with a different on-roll produces a different physical layout (asymmetry check)', () => {
+    // The starting-position id was encoded with white on roll. Decoding
+    // with black on roll interprets tan arrays as if black were on roll,
+    // which physically reshuffles which clockwise points hold which color.
+    const boardWhite = fromPositionId(STARTING_POSITION_ID, WHITE_CW)
+    const boardBlack = fromPositionId(STARTING_POSITION_ID, BLACK_CCW)
+
+    const cw = (board: typeof boardWhite, i: number) =>
+      board.points.find((p) => p.position.clockwise === i)!
+    // White-on-roll decode: white at clockwise 6.
+    expect(cw(boardWhite, 6).checkers.filter((c) => c.color === 'white')).toHaveLength(5)
+    // Black-on-roll decode of the SAME id: black's point 6 (on-roll
+    // perspective) → counterclockwise 6 = clockwise 19. So black ends
+    // up at clockwise 19 and white (now opponent, clockwise) at 6.
+    expect(cw(boardBlack, 19).checkers.filter((c) => c.color === 'black')).toHaveLength(5)
+    expect(cw(boardBlack, 6).checkers.filter((c) => c.color === 'white')).toHaveLength(5)
+  })
+})
+
+describe('encode → decode roundtrip', () => {
+  // Roundtrip through core's Board.initialize + exportToGnuPositionId.
+  // If this breaks, either the encoder or decoder has drifted from the
+  // shared TanBoard convention.
+  it('starting-position → id → decoded tan arrays → board → id is stable', async () => {
+    const Core = await import('../index')
+    const CoreRoot = await import('../..')
+    const { Player } = CoreRoot
+    const { Game } = await import('../../Game')
+
+    const white = Player.initialize('white', 'clockwise', 'rolling-for-start', false)
+    const black = Player.initialize('black', 'counterclockwise', 'rolling-for-start', false)
+    let game = Game.initialize([white, black])
+    // Advance past rolling-for-start into a state where activePlayer is set.
+    game = Game.rollForStart(game as any) as any
+
+    const id = Core.exportToGnuPositionId(game)
+    expect(id).toHaveLength(14)
+
+    const onRoll: OnRollContext = {
+      color: (game as any).activePlayer.color,
+      direction: (game as any).activePlayer.direction,
+    }
+
+    const board = fromPositionId(id, onRoll)
+    // Reconstruct the game with the decoded board and re-encode.
+    const reencoded = Core.exportToGnuPositionId({
+      ...game,
+      board,
+    } as typeof game)
+    expect(reencoded).toBe(id)
+  })
+})

--- a/src/Board/__tests__/frame.test.ts
+++ b/src/Board/__tests__/frame.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from '@jest/globals'
+import {
+  classifyRegion,
+  fromGnuFrame,
+  opponentOf,
+  toGnuFrame,
+} from '../frame'
+
+describe('fromGnuFrame / toGnuFrame', () => {
+  it('passes through 0 (off) and 25 (bar) regardless of direction', () => {
+    for (const dir of ['clockwise', 'counterclockwise'] as const) {
+      expect(fromGnuFrame(0, dir)).toBe(0)
+      expect(fromGnuFrame(25, dir)).toBe(25)
+      expect(toGnuFrame(0, dir)).toBe(0)
+      expect(toGnuFrame(25, dir)).toBe(25)
+    }
+  })
+
+  it('is the identity when on-roll player is clockwise', () => {
+    for (let p = 1; p <= 24; p++) {
+      expect(fromGnuFrame(p, 'clockwise')).toBe(p)
+      expect(toGnuFrame(p, 'clockwise')).toBe(p)
+    }
+  })
+
+  it('flips point numbers (p ↔ 25 - p) when on-roll is counterclockwise', () => {
+    for (let p = 1; p <= 24; p++) {
+      expect(fromGnuFrame(p, 'counterclockwise')).toBe(25 - p)
+      expect(toGnuFrame(p, 'counterclockwise')).toBe(25 - p)
+    }
+  })
+
+  it('fromGnuFrame and toGnuFrame are mutual inverses', () => {
+    for (const dir of ['clockwise', 'counterclockwise'] as const) {
+      for (let p = 1; p <= 24; p++) {
+        expect(toGnuFrame(fromGnuFrame(p, dir), dir)).toBe(p)
+        expect(fromGnuFrame(toGnuFrame(p, dir), dir)).toBe(p)
+      }
+    }
+  })
+})
+
+describe('classifyRegion', () => {
+  const ctx = { direction: 'clockwise' as const }
+
+  it('returns "bar" for 25 and the string "bar"', () => {
+    expect(classifyRegion(25, ctx)).toBe('bar')
+    expect(classifyRegion('bar', ctx)).toBe('bar')
+  })
+
+  it('returns "off" for 0 and the string "off"', () => {
+    expect(classifyRegion(0, ctx)).toBe('off')
+    expect(classifyRegion('off', ctx)).toBe('off')
+  })
+
+  it('classifies 1-3 as bearingOff', () => {
+    for (const p of [1, 2, 3]) expect(classifyRegion(p, ctx)).toBe('bearingOff')
+  })
+
+  it('classifies 4-6 as homeInner', () => {
+    for (const p of [4, 5, 6]) expect(classifyRegion(p, ctx)).toBe('homeInner')
+  })
+
+  it('classifies 7-12 as outerBoard', () => {
+    for (let p = 7; p <= 12; p++) expect(classifyRegion(p, ctx)).toBe('outerBoard')
+  })
+
+  it('classifies 13-18 as opponentOuter', () => {
+    for (let p = 13; p <= 18; p++)
+      expect(classifyRegion(p, ctx)).toBe('opponentOuter')
+  })
+
+  it('classifies 19-21 as opponentInner', () => {
+    for (const p of [19, 20, 21])
+      expect(classifyRegion(p, ctx)).toBe('opponentInner')
+  })
+
+  it('classifies 22-24 as opponentBearing', () => {
+    for (const p of [22, 23, 24])
+      expect(classifyRegion(p, ctx)).toBe('opponentBearing')
+  })
+
+  it('parses numeric strings', () => {
+    expect(classifyRegion('5', ctx)).toBe('homeInner')
+    expect(classifyRegion('20', ctx)).toBe('opponentInner')
+  })
+
+  it('falls back to outerBoard for NaN / out-of-range numerics', () => {
+    expect(classifyRegion('abc', ctx)).toBe('outerBoard')
+  })
+
+  it('returns the same region regardless of on-roll direction — the arg exists for frame intent, not output', () => {
+    for (let p = 1; p <= 24; p++) {
+      const cw = classifyRegion(p, { direction: 'clockwise' })
+      const ccw = classifyRegion(p, { direction: 'counterclockwise' })
+      expect(cw).toBe(ccw)
+    }
+  })
+})
+
+describe('opponentOf', () => {
+  it('swaps color and direction', () => {
+    expect(
+      opponentOf({ color: 'white', direction: 'clockwise' })
+    ).toEqual({ color: 'black', direction: 'counterclockwise' })
+    expect(
+      opponentOf({ color: 'black', direction: 'counterclockwise' })
+    ).toEqual({ color: 'white', direction: 'clockwise' })
+    expect(
+      opponentOf({ color: 'white', direction: 'counterclockwise' })
+    ).toEqual({ color: 'black', direction: 'clockwise' })
+  })
+})

--- a/src/Board/decodePositionId.ts
+++ b/src/Board/decodePositionId.ts
@@ -1,0 +1,118 @@
+/**
+ * Pure-TS decoder for GNU Backgammon position IDs.
+ *
+ * The companion encoder lives at ./gnuPositionId.ts. Both follow the
+ * same convention (see gnuPositionId.ts:42):
+ *   TanBoard[0] (bitstream first)  = opponent (NOT on roll)
+ *   TanBoard[1] (bitstream second) = player on roll
+ *
+ * Each 25-entry tan array is indexed [0..23] for points 1..24 in that
+ * player's own direction; index 24 is their bar.
+ *
+ * Field names `x` and `o` are historical (x = first read, o = second
+ * read) and do NOT refer to board colors. `x` is always the opponent;
+ * `o` is always the player on roll. Callers must supply an on-roll
+ * context to map these to concrete players — see importFromDecoded().
+ */
+
+const BASE64_CHARS =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+
+export interface DecodedGnuBoard {
+  /** TanBoard[0] — opponent's checkers. 25 entries: 0-23 points 1-24, 24 bar. */
+  x: number[]
+  /** TanBoard[1] — player-on-roll's checkers. 25 entries: 0-23 points 1-24, 24 bar. */
+  o: number[]
+}
+
+function base64Value(ch: string): number {
+  const idx = BASE64_CHARS.indexOf(ch)
+  return idx >= 0 ? idx : 0
+}
+
+function keyFromPositionId(positionId: string): Uint8Array {
+  if (positionId.length !== 14) {
+    throw new Error(
+      `Invalid position ID length: ${positionId.length}, expected 14`
+    )
+  }
+
+  const key = new Uint8Array(10)
+  let keyIdx = 0
+
+  // Three groups of 4 base64 chars = 3 bytes each.
+  for (let i = 0; i < 3; i++) {
+    const c0 = base64Value(positionId[i * 4])
+    const c1 = base64Value(positionId[i * 4 + 1])
+    const c2 = base64Value(positionId[i * 4 + 2])
+    const c3 = base64Value(positionId[i * 4 + 3])
+
+    key[keyIdx++] = (c0 << 2) | (c1 >> 4)
+    key[keyIdx++] = ((c1 & 0x0f) << 4) | (c2 >> 2)
+    key[keyIdx++] = ((c2 & 0x03) << 6) | c3
+  }
+
+  // Final 2 base64 chars = 1 byte.
+  const c0 = base64Value(positionId[12])
+  const c1 = base64Value(positionId[13])
+  key[keyIdx] = (c0 << 2) | (c1 >> 4)
+
+  return key
+}
+
+function boardFromKey(key: Uint8Array): DecodedGnuBoard {
+  const board: DecodedGnuBoard = {
+    x: new Array(25).fill(0),
+    o: new Array(25).fill(0),
+  }
+
+  let bitPos = 0
+
+  // Two players: TanBoard[0] first (opponent), then TanBoard[1] (on roll).
+  // 25 positions each: points 1-24 then bar. Each count is encoded as
+  // N ones followed by a terminating zero (unary).
+  for (let player = 0; player < 2; player++) {
+    const arr = player === 0 ? board.x : board.o
+
+    for (let point = 0; point < 25; point++) {
+      let checkerCount = 0
+
+      while (true) {
+        const byteIdx = Math.floor(bitPos / 8)
+        const bitIdx = bitPos % 8
+
+        if (byteIdx >= 10) break
+
+        const bit = (key[byteIdx] >> bitIdx) & 1
+        bitPos++
+
+        if (bit === 0) break
+        checkerCount++
+      }
+
+      arr[point] = checkerCount
+    }
+  }
+
+  return board
+}
+
+/**
+ * Decode a 14-character GNU Backgammon position ID.
+ *
+ * Returns two tan arrays where `x` is the opponent (TanBoard[0]) and
+ * `o` is the player on roll (TanBoard[1]). Callers that need to render
+ * must pair these with an on-roll color/direction via importFromDecoded.
+ *
+ * @throws Error if the position ID is not exactly 14 characters.
+ */
+export function decodePositionId(positionId: string): DecodedGnuBoard {
+  if (!positionId || positionId.length !== 14) {
+    throw new Error(
+      `Invalid position ID: expected 14 characters, got ${positionId?.length ?? 0}`
+    )
+  }
+
+  const key = keyFromPositionId(positionId)
+  return boardFromKey(key)
+}

--- a/src/Board/frame.ts
+++ b/src/Board/frame.ts
@@ -1,0 +1,120 @@
+import type {
+  BackgammonColor,
+  BackgammonMoveDirection,
+} from '@nodots/backgammon-types'
+
+/**
+ * Coordinate-frame helpers and board-region classifier.
+ *
+ * Convention:
+ *   - "GNU frame" is the 1-24 numbering from the on-roll player's
+ *     own direction of travel. This is what the GNU native addon
+ *     returns in MoveHint.moves[i].from / .to.
+ *   - "Clockwise frame" is the 1-24 numbering used for rendering.
+ *     The UI treats clockwise = 1..24 as a fixed coordinate system;
+ *     the counterclockwise player sees the same points as 24..1 in
+ *     their own frame, and the board is visually flipped for them.
+ *
+ * When the on-roll player moves clockwise, GNU's frame already
+ * matches the clockwise rendering frame. When the on-roll player
+ * moves counterclockwise, each point number must be flipped
+ * (p → 25 - p).
+ *
+ * Special values pass through unchanged:
+ *   0  = off (bear-off)
+ *   25 = bar
+ */
+
+export type BoardRegion =
+  | 'bearingOff'
+  | 'homeInner'
+  | 'outerBoard'
+  | 'opponentOuter'
+  | 'opponentInner'
+  | 'opponentBearing'
+  | 'bar'
+  | 'off'
+
+export interface OnRollContext {
+  color: BackgammonColor
+  direction: BackgammonMoveDirection
+}
+
+const BAR = 25
+const OFF = 0
+
+/**
+ * Flip a GNU-frame point (1-24, from on-roll's direction) into the
+ * clockwise 1-24 frame used for rendering. Pass 0/25 through.
+ */
+export function fromGnuFrame(
+  point: number,
+  onRollDirection: BackgammonMoveDirection
+): number {
+  if (point === BAR || point === OFF) return point
+  if (point < 1 || point > 24) return point
+  return onRollDirection === 'clockwise' ? point : 25 - point
+}
+
+/**
+ * Flip a clockwise-frame point (1-24) into the GNU on-roll frame.
+ * Inverse of fromGnuFrame. Pass 0/25 through.
+ */
+export function toGnuFrame(
+  clockwisePoint: number,
+  onRollDirection: BackgammonMoveDirection
+): number {
+  // The flip is symmetric, but exposing both names makes call sites
+  // self-documenting about which direction the conversion runs.
+  return fromGnuFrame(clockwisePoint, onRollDirection)
+}
+
+/**
+ * Classify a point in the GNU on-roll frame as a board region from
+ * the on-roll player's perspective. Preserves the bucket names the
+ * API already uses for PR/stats aggregation.
+ *
+ *   1-3   = bearingOff
+ *   4-6   = homeInner
+ *   7-12  = outerBoard
+ *   13-18 = opponentOuter
+ *   19-21 = opponentInner
+ *   22-24 = opponentBearing
+ *   0     = off
+ *   25    = bar
+ *
+ * Replaces the point-only classifier that lived in
+ * api/src/utils/pr-extraction.ts. The `onRoll` arg is part of the
+ * signature for forward compatibility and self-documentation: region
+ * names are expressed in the on-roll player's frame, and callers must
+ * pre-translate into the on-roll frame before calling.
+ */
+export function classifyRegion(
+  point: number | string,
+  _onRoll: Pick<OnRollContext, 'direction'>
+): BoardRegion {
+  if (point === 'bar' || point === BAR) return 'bar'
+  if (point === 'off' || point === OFF) return 'off'
+
+  const pos = typeof point === 'number' ? point : parseInt(point, 10)
+  if (Number.isNaN(pos)) return 'outerBoard'
+
+  if (pos >= 1 && pos <= 3) return 'bearingOff'
+  if (pos >= 4 && pos <= 6) return 'homeInner'
+  if (pos >= 7 && pos <= 12) return 'outerBoard'
+  if (pos >= 13 && pos <= 18) return 'opponentOuter'
+  if (pos >= 19 && pos <= 21) return 'opponentInner'
+  if (pos >= 22 && pos <= 24) return 'opponentBearing'
+
+  return 'outerBoard'
+}
+
+/**
+ * Given an on-roll color, return the opposing color.
+ */
+export function opponentOf(ctx: OnRollContext): OnRollContext {
+  return {
+    color: ctx.color === 'white' ? 'black' : 'white',
+    direction: ctx.direction === 'clockwise' ? 'counterclockwise' : 'clockwise',
+  }
+}

--- a/src/Board/fromPositionId.ts
+++ b/src/Board/fromPositionId.ts
@@ -1,0 +1,28 @@
+import type { BackgammonBoard } from '@nodots/backgammon-types'
+import { decodePositionId } from './decodePositionId'
+import type { OnRollContext } from './frame'
+import { importFromDecoded } from './importFromDecoded'
+
+/**
+ * Convert a 14-character GNU position ID into a fully materialized
+ * BackgammonBoard, given the on-roll player's color and direction.
+ *
+ * Composes the three primitives in this directory:
+ *   decodePositionId → importFromDecoded → Board.initialize
+ *
+ * Placed in its own file so the circular import with Board.initialize
+ * is resolved through a lazy require in the function body; callers
+ * just import this one function.
+ */
+export function fromPositionId(
+  positionId: string,
+  onRoll: OnRollContext
+): BackgammonBoard {
+  const decoded = decodePositionId(positionId)
+  const imports = importFromDecoded(decoded, onRoll)
+  // Lazy require avoids the cycle between index.ts (exports Board and
+  // these helpers) and this helper (which needs Board.initialize).
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { Board } = require('./index') as typeof import('./index')
+  return Board.initialize(imports)
+}

--- a/src/Board/importFromDecoded.ts
+++ b/src/Board/importFromDecoded.ts
@@ -1,0 +1,81 @@
+import type {
+  BackgammonCheckerContainerImport,
+  BackgammonPointValue,
+} from '@nodots/backgammon-types'
+import type { DecodedGnuBoard } from './decodePositionId'
+import { opponentOf, type OnRollContext } from './frame'
+
+const CHECKERS_PER_PLAYER = 15
+
+const toPointValue = (value: number): BackgammonPointValue =>
+  value as BackgammonPointValue
+
+/**
+ * Map the two tan arrays from a decoded position ID onto concrete
+ * BackgammonCheckerContainerImport entries.
+ *
+ * Callers must supply an on-roll context (color + direction). The
+ * decoder's `x` array is the opponent (TanBoard[0]) and `o` is the
+ * player on roll (TanBoard[1]); each array is indexed 0..23 for points
+ * 1..24 in that player's own direction, with index 24 = bar.
+ *
+ * Output is the shape `Board.initialize(imports)` consumes.
+ */
+export function importFromDecoded(
+  decoded: DecodedGnuBoard,
+  onRoll: OnRollContext
+): BackgammonCheckerContainerImport[] {
+  const opponent = opponentOf(onRoll)
+  const imports: BackgammonCheckerContainerImport[] = []
+
+  const addPoints = (tan: number[], player: OnRollContext) => {
+    for (let i = 0; i < 24; i++) {
+      if (tan[i] <= 0) continue
+      const playerPos = i + 1
+      const clockwise =
+        player.direction === 'clockwise' ? playerPos : 25 - playerPos
+      const counterclockwise = 25 - clockwise
+      imports.push({
+        position: {
+          clockwise: toPointValue(clockwise),
+          counterclockwise: toPointValue(counterclockwise),
+        },
+        checkers: { color: player.color, qty: tan[i] },
+      })
+    }
+    if (tan[24] > 0) {
+      imports.push({
+        position: 'bar',
+        direction: player.direction,
+        checkers: { color: player.color, qty: tan[24] },
+      })
+    }
+  }
+
+  addPoints(decoded.x, opponent) // TanBoard[0]
+  addPoints(decoded.o, onRoll) // TanBoard[1]
+
+  // Off count = 15 minus (points + bar) for that player.
+  const onBoardCount = (tan: number[]) =>
+    tan.slice(0, 24).reduce((sum, n) => sum + n, 0) + tan[24]
+
+  const opponentOff = Math.max(0, CHECKERS_PER_PLAYER - onBoardCount(decoded.x))
+  const onRollOff = Math.max(0, CHECKERS_PER_PLAYER - onBoardCount(decoded.o))
+
+  if (opponentOff > 0) {
+    imports.push({
+      position: 'off',
+      direction: opponent.direction,
+      checkers: { color: opponent.color, qty: opponentOff },
+    })
+  }
+  if (onRollOff > 0) {
+    imports.push({
+      position: 'off',
+      direction: onRoll.direction,
+      checkers: { color: onRoll.color, qty: onRollOff },
+    })
+  }
+
+  return imports
+}

--- a/src/Board/index.ts
+++ b/src/Board/index.ts
@@ -25,6 +25,18 @@ import {
   getPossibleMovesWithPositionSpecificAutoSwitch,
 } from './methods/getPossibleMoves'
 export { exportToGnuPositionId } from './gnuPositionId'
+export { decodePositionId, type DecodedGnuBoard } from './decodePositionId'
+export { importFromDecoded } from './importFromDecoded'
+export { fromPositionId } from './fromPositionId'
+export { calculatePipCount } from './pipCount'
+export {
+  fromGnuFrame,
+  toGnuFrame,
+  classifyRegion,
+  opponentOf,
+  type BoardRegion,
+  type OnRollContext,
+} from './frame'
 
 export const BOARD_POINT_COUNT = 24
 

--- a/src/Board/pipCount.ts
+++ b/src/Board/pipCount.ts
@@ -1,0 +1,38 @@
+import type {
+  BackgammonBoard,
+  BackgammonColor,
+  BackgammonMoveDirection,
+  BackgammonPlayerInactive,
+} from '@nodots/backgammon-types'
+
+const toPips = (value: number): BackgammonPlayerInactive['pipCount'] =>
+  value as BackgammonPlayerInactive['pipCount']
+
+/**
+ * Compute a player's pip count in their own direction of travel.
+ *
+ * Iterates every point and counts checkers matching `color`, then
+ * multiplies by that point's position number in `direction`. Checkers
+ * on the player's bar contribute 25 pips each.
+ */
+export function calculatePipCount(
+  board: BackgammonBoard,
+  color: BackgammonColor,
+  direction: BackgammonMoveDirection
+): BackgammonPlayerInactive['pipCount'] {
+  let total = 0
+
+  board.points.forEach((point) => {
+    const count = point.checkers.filter((c) => c.color === color).length
+    if (count > 0) {
+      total += count * point.position[direction]
+    }
+  })
+
+  const barCount = board.bar[direction].checkers.filter(
+    (c) => c.color === color
+  ).length
+  total += barCount * 25
+
+  return toPips(total)
+}


### PR DESCRIPTION
Step 1 of https://github.com/nodots/backgammon/issues/324.

## What

Adds decoder, on-roll-aware board builder, and coordinate-frame helpers alongside the existing encoder in `src/Board/`, giving downstream packages a single place to consume.

New exports from `Core.Board`:

- `decodePositionId(positionId)` — pure-TS GNU position-ID decoder.
- `importFromDecoded(decoded, onRoll)` — maps the two tan arrays to `BackgammonCheckerContainerImport[]` against a supplied on-roll color/direction.
- `fromPositionId(positionId, onRoll)` — composes decode → import → `Board.initialize`.
- `calculatePipCount(board, color, direction)` — lifted from client.
- `fromGnuFrame(point, direction)` / `toGnuFrame(point, direction)` — flip between GNU on-roll frame and clockwise rendering frame.
- `classifyRegion(point, onRoll)` — same buckets the api already uses (`bearingOff`/`homeInner`/`outerBoard`/`opponentOuter`/`opponentInner`/`opponentBearing`/`bar`/`off`).

## Why

Position-ID handling was split across three packages and drifting. The client decoder had stale docs, hardcoded `x=white/clockwise` regardless of who rolled, and rendered the practice board with players swapped for non-default orientations. API hint text also emits raw GNU-frame point numbers without a frame flip. This PR lands the one place everything should call into; follow-up PRs migrate the callers.

## Test

- `src/Board/__tests__/frame.test.ts` — exhaustive table for `fromGnuFrame`/`toGnuFrame` (both directions, 1-24 + bar/off), and region buckets matching the legacy `classifyBoardLocation` output.
- `src/Board/__tests__/decodePositionId.test.ts` — decoder shape, starting-position point counts, symmetric on-roll cases, bar + off placement under `importFromDecoded`, `fromPositionId` roundtrip against the encoder.
- 27 new tests pass. Full core suite: 458 pass, 1 pre-existing unrelated failure (`move-and-finalize.test.ts`), 12 skipped.

## Follow-ups (separate PRs)

- `packages/api`: migrate `routes/practice.ts`, `routes/pr.ts`, `routes/stats.ts`, and scripts from `classifyBoardLocation` / raw `bestHint.moves[].from` to `Core.Board.classifyRegion` + `Core.Board.fromGnuFrame`. Fixes the currently-visible practice-hint coordinate bug.
- `packages/client`: delete local `positionDecoder.ts` + `boardBuilder.ts`; switch `ReviewBoard`, `PracticeBoard`, `UserStatsPage` utils to the new core API. Fix Jest `uuid` ESM config.

## Risk

- No existing exports removed; additive only.
- `fromPositionId.ts` uses a lazy `require` into `./index` to resolve the cycle between `index.ts` (which re-exports these helpers) and `Board.initialize`. Noted inline.