### PR TITLE
chore: bump core to 1.0.0-rc.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nodots/backgammon-core",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nodots/backgammon-core",
-      "version": "1.0.0-rc.1",
+      "version": "1.0.0-rc.5",
       "license": "GPL-3.0",
       "dependencies": {
         "@nodots/backgammon-types": "^1.0.0-rc.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nodots/backgammon-core",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.5",
   "description": "Core game logic for Nodots Backgammon",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Version bump so the position-encoding consolidation (decoder + coordinate-frame helpers, PR #121) + lock-file fix (PR #122) can publish to npm as 1.0.0-rc.5.

Unblocks the api/client migrations in https://github.com/nodots/backgammon/issues/324 by letting them depend on a published core with the new exports instead of a workspace symlink.