### PR TITLE
feat(board)!: finalize position-encoding API before 1.0 publish

### DIFF
--- a/src/Board/__tests__/decodePositionId.test.ts
+++ b/src/Board/__tests__/decodePositionId.test.ts
@@ -18,21 +18,21 @@ describe('decodePositionId', () => {
 
   it('returns two 25-entry arrays for a valid id', () => {
     const decoded = decodePositionId(STARTING_POSITION_ID)
-    expect(decoded.x).toHaveLength(25)
-    expect(decoded.o).toHaveLength(25)
+    expect(decoded.opponent).toHaveLength(25)
+    expect(decoded.onRoll).toHaveLength(25)
   })
 
   it('starting position puts 15 checkers on each tan array', () => {
     const decoded = decodePositionId(STARTING_POSITION_ID)
     const total = (arr: number[]) => arr.reduce((s, n) => s + n, 0)
-    expect(total(decoded.x)).toBe(15)
-    expect(total(decoded.o)).toBe(15)
+    expect(total(decoded.opponent)).toBe(15)
+    expect(total(decoded.onRoll)).toBe(15)
   })
 
   it('starting position has checker counts at points 6, 8, 13, 24 (2/3/5/5)', () => {
     const decoded = decodePositionId(STARTING_POSITION_ID)
     // Both tan arrays are symmetric at the starting position.
-    for (const tan of [decoded.x, decoded.o]) {
+    for (const tan of [decoded.opponent, decoded.onRoll]) {
       expect(tan[5]).toBe(5) // point 6
       expect(tan[7]).toBe(3) // point 8
       expect(tan[12]).toBe(5) // point 13
@@ -43,18 +43,18 @@ describe('decodePositionId', () => {
 })
 
 describe('importFromDecoded', () => {
-  it('maps x onto the opponent and o onto the on-roll player', () => {
+  it('maps decoded.opponent and decoded.onRoll onto the right players', () => {
     const decoded: DecodedGnuBoard = {
-      x: new Array(25).fill(0),
-      o: new Array(25).fill(0),
+      opponent: new Array(25).fill(0),
+      onRoll: new Array(25).fill(0),
     }
-    decoded.x[0] = 1 // opponent at opponent's point 1
-    decoded.o[0] = 1 // on-roll at on-roll's point 1
-    decoded.x[5] = 14
-    decoded.o[5] = 14
+    decoded.opponent[0] = 1 // opponent at opponent's point 1
+    decoded.onRoll[0] = 1 // on-roll at on-roll's point 1
+    decoded.opponent[5] = 14
+    decoded.onRoll[5] = 14
 
     const imports = importFromDecoded(decoded, WHITE_CW)
-    // On-roll = white/clockwise: o[0] → clockwise 1, color white.
+    // On-roll = white/clockwise: onRoll[0] → clockwise 1, color white.
     const onRollFirst = imports.find(
       (cc) =>
         typeof cc.position === 'object' &&
@@ -65,8 +65,9 @@ describe('importFromDecoded', () => {
     )
     expect(onRollFirst).toBeDefined()
 
-    // Opponent = black/counterclockwise: x[0] at opponent point 1 in
-    // counterclockwise direction → counterclockwise 1 = clockwise 24.
+    // Opponent = black/counterclockwise: opponent[0] at opponent
+    // point 1 in counterclockwise direction → counterclockwise 1 =
+    // clockwise 24.
     const opponentFirst = imports.find(
       (cc) =>
         typeof cc.position === 'object' &&
@@ -80,16 +81,16 @@ describe('importFromDecoded', () => {
 
   it('flips placement when on-roll is black/counterclockwise', () => {
     const decoded: DecodedGnuBoard = {
-      x: new Array(25).fill(0),
-      o: new Array(25).fill(0),
+      opponent: new Array(25).fill(0),
+      onRoll: new Array(25).fill(0),
     }
-    decoded.o[0] = 1 // on-roll at on-roll's point 1
-    decoded.x[0] = 1 // opponent at opponent's point 1
-    decoded.o[5] = 14
-    decoded.x[5] = 14
+    decoded.onRoll[0] = 1 // on-roll at on-roll's point 1
+    decoded.opponent[0] = 1 // opponent at opponent's point 1
+    decoded.onRoll[5] = 14
+    decoded.opponent[5] = 14
 
     const imports = importFromDecoded(decoded, BLACK_CCW)
-    // On-roll = black/counterclockwise: o[0] → counterclockwise 1 = clockwise 24.
+    // On-roll = black/counterclockwise: onRoll[0] → counterclockwise 1 = clockwise 24.
     const onRollFirst = imports.find(
       (cc) =>
         typeof cc.position === 'object' &&
@@ -100,7 +101,7 @@ describe('importFromDecoded', () => {
     )
     expect(onRollFirst).toBeDefined()
 
-    // Opponent = white/clockwise: x[0] → clockwise 1, color white.
+    // Opponent = white/clockwise: opponent[0] → clockwise 1, color white.
     const opponentFirst = imports.find(
       (cc) =>
         typeof cc.position === 'object' &&
@@ -114,12 +115,12 @@ describe('importFromDecoded', () => {
 
   it('places bar checkers on the correct direction container', () => {
     const decoded: DecodedGnuBoard = {
-      x: new Array(25).fill(0),
-      o: new Array(25).fill(0),
+      opponent: new Array(25).fill(0),
+      onRoll: new Array(25).fill(0),
     }
-    decoded.o[24] = 2 // on-roll on bar
-    decoded.o[5] = 13
-    decoded.x[5] = 15
+    decoded.onRoll[24] = 2 // on-roll on bar
+    decoded.onRoll[5] = 13
+    decoded.opponent[5] = 15
 
     const imports = importFromDecoded(decoded, WHITE_CW)
     const bar = imports.find(
@@ -133,11 +134,11 @@ describe('importFromDecoded', () => {
 
   it('emits off containers when a player has borne off', () => {
     const decoded: DecodedGnuBoard = {
-      x: new Array(25).fill(0),
-      o: new Array(25).fill(0),
+      opponent: new Array(25).fill(0),
+      onRoll: new Array(25).fill(0),
     }
-    decoded.o[5] = 10 // 10 on-roll on point 6 → 5 off
-    decoded.x[5] = 15 // opponent full on point 6
+    decoded.onRoll[5] = 10 // 10 on-roll on point 6 → 5 off
+    decoded.opponent[5] = 15 // opponent full on point 6
 
     const imports = importFromDecoded(decoded, WHITE_CW)
     const off = imports.find(

--- a/src/Board/__tests__/frame.test.ts
+++ b/src/Board/__tests__/frame.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from '@jest/globals'
-import {
-  classifyRegion,
-  fromGnuFrame,
-  opponentOf,
-  toGnuFrame,
-} from '../frame'
+import { classifyRegion, fromGnuFrame, toGnuFrame } from '../frame'
 
 describe('fromGnuFrame / toGnuFrame', () => {
   it('passes through 0 (off) and 25 (bar) regardless of direction', () => {
@@ -41,73 +36,53 @@ describe('fromGnuFrame / toGnuFrame', () => {
 })
 
 describe('classifyRegion', () => {
-  const ctx = { direction: 'clockwise' as const }
-
   it('returns "bar" for 25 and the string "bar"', () => {
-    expect(classifyRegion(25, ctx)).toBe('bar')
-    expect(classifyRegion('bar', ctx)).toBe('bar')
+    expect(classifyRegion(25)).toBe('bar')
+    expect(classifyRegion('bar')).toBe('bar')
   })
 
   it('returns "off" for 0 and the string "off"', () => {
-    expect(classifyRegion(0, ctx)).toBe('off')
-    expect(classifyRegion('off', ctx)).toBe('off')
+    expect(classifyRegion(0)).toBe('off')
+    expect(classifyRegion('off')).toBe('off')
   })
 
   it('classifies 1-3 as bearingOff', () => {
-    for (const p of [1, 2, 3]) expect(classifyRegion(p, ctx)).toBe('bearingOff')
+    for (const p of [1, 2, 3]) expect(classifyRegion(p)).toBe('bearingOff')
   })
 
   it('classifies 4-6 as homeInner', () => {
-    for (const p of [4, 5, 6]) expect(classifyRegion(p, ctx)).toBe('homeInner')
+    for (const p of [4, 5, 6]) expect(classifyRegion(p)).toBe('homeInner')
   })
 
   it('classifies 7-12 as outerBoard', () => {
-    for (let p = 7; p <= 12; p++) expect(classifyRegion(p, ctx)).toBe('outerBoard')
+    for (let p = 7; p <= 12; p++) expect(classifyRegion(p)).toBe('outerBoard')
   })
 
   it('classifies 13-18 as opponentOuter', () => {
     for (let p = 13; p <= 18; p++)
-      expect(classifyRegion(p, ctx)).toBe('opponentOuter')
+      expect(classifyRegion(p)).toBe('opponentOuter')
   })
 
   it('classifies 19-21 as opponentInner', () => {
     for (const p of [19, 20, 21])
-      expect(classifyRegion(p, ctx)).toBe('opponentInner')
+      expect(classifyRegion(p)).toBe('opponentInner')
   })
 
   it('classifies 22-24 as opponentBearing', () => {
     for (const p of [22, 23, 24])
-      expect(classifyRegion(p, ctx)).toBe('opponentBearing')
+      expect(classifyRegion(p)).toBe('opponentBearing')
   })
 
   it('parses numeric strings', () => {
-    expect(classifyRegion('5', ctx)).toBe('homeInner')
-    expect(classifyRegion('20', ctx)).toBe('opponentInner')
+    expect(classifyRegion('5')).toBe('homeInner')
+    expect(classifyRegion('20')).toBe('opponentInner')
   })
 
   it('falls back to outerBoard for NaN / out-of-range numerics', () => {
-    expect(classifyRegion('abc', ctx)).toBe('outerBoard')
-  })
-
-  it('returns the same region regardless of on-roll direction — the arg exists for frame intent, not output', () => {
-    for (let p = 1; p <= 24; p++) {
-      const cw = classifyRegion(p, { direction: 'clockwise' })
-      const ccw = classifyRegion(p, { direction: 'counterclockwise' })
-      expect(cw).toBe(ccw)
-    }
+    expect(classifyRegion('abc')).toBe('outerBoard')
   })
 })
 
-describe('opponentOf', () => {
-  it('swaps color and direction', () => {
-    expect(
-      opponentOf({ color: 'white', direction: 'clockwise' })
-    ).toEqual({ color: 'black', direction: 'counterclockwise' })
-    expect(
-      opponentOf({ color: 'black', direction: 'counterclockwise' })
-    ).toEqual({ color: 'white', direction: 'clockwise' })
-    expect(
-      opponentOf({ color: 'white', direction: 'counterclockwise' })
-    ).toEqual({ color: 'black', direction: 'clockwise' })
-  })
-})
+// opponentOf is internal to the Board module; it's exercised through
+// importFromDecoded behavior in decodePositionId.test.ts rather than
+// as a direct public-API test.

--- a/src/Board/decodePositionId.ts
+++ b/src/Board/decodePositionId.ts
@@ -7,12 +7,9 @@
  *   TanBoard[1] (bitstream second) = player on roll
  *
  * Each 25-entry tan array is indexed [0..23] for points 1..24 in that
- * player's own direction; index 24 is their bar.
- *
- * Field names `x` and `o` are historical (x = first read, o = second
- * read) and do NOT refer to board colors. `x` is always the opponent;
- * `o` is always the player on roll. Callers must supply an on-roll
- * context to map these to concrete players — see importFromDecoded().
+ * player's own direction; index 24 is their bar. Callers must supply
+ * an on-roll context (color + direction) to map these arrays to
+ * concrete players — see importFromDecoded().
  */
 
 const BASE64_CHARS =
@@ -20,9 +17,9 @@ const BASE64_CHARS =
 
 export interface DecodedGnuBoard {
   /** TanBoard[0] — opponent's checkers. 25 entries: 0-23 points 1-24, 24 bar. */
-  x: number[]
+  opponent: number[]
   /** TanBoard[1] — player-on-roll's checkers. 25 entries: 0-23 points 1-24, 24 bar. */
-  o: number[]
+  onRoll: number[]
 }
 
 function base64Value(ch: string): number {
@@ -62,8 +59,8 @@ function keyFromPositionId(positionId: string): Uint8Array {
 
 function boardFromKey(key: Uint8Array): DecodedGnuBoard {
   const board: DecodedGnuBoard = {
-    x: new Array(25).fill(0),
-    o: new Array(25).fill(0),
+    opponent: new Array(25).fill(0),
+    onRoll: new Array(25).fill(0),
   }
 
   let bitPos = 0
@@ -72,7 +69,7 @@ function boardFromKey(key: Uint8Array): DecodedGnuBoard {
   // 25 positions each: points 1-24 then bar. Each count is encoded as
   // N ones followed by a terminating zero (unary).
   for (let player = 0; player < 2; player++) {
-    const arr = player === 0 ? board.x : board.o
+    const arr = player === 0 ? board.opponent : board.onRoll
 
     for (let point = 0; point < 25; point++) {
       let checkerCount = 0
@@ -100,9 +97,9 @@ function boardFromKey(key: Uint8Array): DecodedGnuBoard {
 /**
  * Decode a 14-character GNU Backgammon position ID.
  *
- * Returns two tan arrays where `x` is the opponent (TanBoard[0]) and
- * `o` is the player on roll (TanBoard[1]). Callers that need to render
- * must pair these with an on-roll color/direction via importFromDecoded.
+ * Returns two tan arrays: `opponent` (TanBoard[0]) and `onRoll`
+ * (TanBoard[1]). Callers that need to render must pair these with an
+ * on-roll color/direction via importFromDecoded.
  *
  * @throws Error if the position ID is not exactly 14 characters.
  */

--- a/src/Board/frame.ts
+++ b/src/Board/frame.ts
@@ -70,9 +70,10 @@ export function toGnuFrame(
 }
 
 /**
- * Classify a point in the GNU on-roll frame as a board region from
- * the on-roll player's perspective. Preserves the bucket names the
- * API already uses for PR/stats aggregation.
+ * Classify a 1-24 point number as a board region from the point
+ * owner's perspective. Direction-invariant: callers must pre-translate
+ * into the owner's direction frame before calling (use fromGnuFrame
+ * / toGnuFrame for that).
  *
  *   1-3   = bearingOff
  *   4-6   = homeInner
@@ -83,16 +84,9 @@ export function toGnuFrame(
  *   0     = off
  *   25    = bar
  *
- * Replaces the point-only classifier that lived in
- * api/src/utils/pr-extraction.ts. The `onRoll` arg is part of the
- * signature for forward compatibility and self-documentation: region
- * names are expressed in the on-roll player's frame, and callers must
- * pre-translate into the on-roll frame before calling.
+ * Replaces the classifier that lived in api/src/utils/pr-extraction.ts.
  */
-export function classifyRegion(
-  point: number | string,
-  _onRoll: Pick<OnRollContext, 'direction'>
-): BoardRegion {
+export function classifyRegion(point: number | string): BoardRegion {
   if (point === 'bar' || point === BAR) return 'bar'
   if (point === 'off' || point === OFF) return 'off'
 
@@ -109,9 +103,9 @@ export function classifyRegion(
   return 'outerBoard'
 }
 
-/**
- * Given an on-roll color, return the opposing color.
- */
+// Internal helper: given an on-roll color/direction, return the
+// opposing player's color/direction. Not exported — callers can
+// compute this themselves if they need it.
 export function opponentOf(ctx: OnRollContext): OnRollContext {
   return {
     color: ctx.color === 'white' ? 'black' : 'white',

--- a/src/Board/importFromDecoded.ts
+++ b/src/Board/importFromDecoded.ts
@@ -15,9 +15,9 @@ const toPointValue = (value: number): BackgammonPointValue =>
  * BackgammonCheckerContainerImport entries.
  *
  * Callers must supply an on-roll context (color + direction). The
- * decoder's `x` array is the opponent (TanBoard[0]) and `o` is the
- * player on roll (TanBoard[1]); each array is indexed 0..23 for points
- * 1..24 in that player's own direction, with index 24 = bar.
+ * decoder's `opponent` array is TanBoard[0] and `onRoll` is
+ * TanBoard[1]; each array is indexed 0..23 for points 1..24 in that
+ * player's own direction, with index 24 = bar.
  *
  * Output is the shape `Board.initialize(imports)` consumes.
  */
@@ -52,15 +52,21 @@ export function importFromDecoded(
     }
   }
 
-  addPoints(decoded.x, opponent) // TanBoard[0]
-  addPoints(decoded.o, onRoll) // TanBoard[1]
+  addPoints(decoded.opponent, opponent) // TanBoard[0]
+  addPoints(decoded.onRoll, onRoll) // TanBoard[1]
 
   // Off count = 15 minus (points + bar) for that player.
   const onBoardCount = (tan: number[]) =>
     tan.slice(0, 24).reduce((sum, n) => sum + n, 0) + tan[24]
 
-  const opponentOff = Math.max(0, CHECKERS_PER_PLAYER - onBoardCount(decoded.x))
-  const onRollOff = Math.max(0, CHECKERS_PER_PLAYER - onBoardCount(decoded.o))
+  const opponentOff = Math.max(
+    0,
+    CHECKERS_PER_PLAYER - onBoardCount(decoded.opponent)
+  )
+  const onRollOff = Math.max(
+    0,
+    CHECKERS_PER_PLAYER - onBoardCount(decoded.onRoll)
+  )
 
   if (opponentOff > 0) {
     imports.push({

--- a/src/Board/index.ts
+++ b/src/Board/index.ts
@@ -33,7 +33,6 @@ export {
   fromGnuFrame,
   toGnuFrame,
   classifyRegion,
-  opponentOf,
   type BoardRegion,
   type OnRollContext,
 } from './frame'


### PR DESCRIPTION
Last-mile cleanup of the position-encoding API added in #121 before core 1.0 goes to npm.

## Breaking changes

**1. \`DecodedGnuBoard.x\` / \`DecodedGnuBoard.o\` → \`.opponent\` / \`.onRoll\`**

The \`x\` / \`o\` names were historical (first/second tan array in the GNU bitstream) and always required a doc comment to interpret — \`x\` is always the opponent (TanBoard[0]), \`o\` is always the player on roll (TanBoard[1]). Naming the fields after the players they actually represent removes that ambiguity at every call site.

**2. \`classifyRegion(point, onRoll)\` → \`classifyRegion(point)\`**

The \`onRoll\` argument was never used — regions are direction-invariant — so keeping it was just ceremony that invited confusion about whether changing direction changed the output. Callers must still pre-translate into the owner's direction frame before calling (use \`fromGnuFrame\` for that).

**3. \`opponentOf\` un-exported from the package root**

Internal helper; callers can compute \`{color, direction}\` inversions themselves when they need it.

## Non-breaking

- \`fromGnuFrame\` / \`toGnuFrame\` kept as separate named exports. They compute the same flip but the name pair makes call sites self-documenting (\"I'm converting from the GNU frame to the render frame\").
- \`fromPositionId\` / \`importFromDecoded\` / \`calculatePipCount\` unchanged.

## Caller impact

- \`packages/api\` PR https://github.com/nodots/backgammon-api/pull/75 — updated to drop the \`{direction:'clockwise'}\` second arg from all five \`classifyRegion\` call sites.
- \`packages/client\` PR https://github.com/nodots/backgammon-client/pull/97 — updated \`gamePhaseDetection.ts\` to read \`board.onRoll\` / \`board.opponent\`. The old code read \`board.x\` / \`board.o\` under the \`x = player, o = opponent\` assumption, which was a latent semantic bug (x is actually the opponent); this corrects that.

## Test

25 tests pass locally (\`frame.test.ts\` + \`decodePositionId.test.ts\`). Core's full suite runs as part of \`smoke-core-sim\` on this PR.

## Unblocks

npm publish of \`@nodots/backgammon-core@1.0.0-rc.5\` with the final 1.0 surface locked in.