### PR TITLE
feat(dice): use crypto.randomInt for die generation (Phase 1.1 of nodots/backgammon#327)

### DIFF
--- a/src/Dice/index.ts
+++ b/src/Dice/index.ts
@@ -1,3 +1,4 @@
+import { randomInt } from 'crypto'
 import {
   BackgammonColor,
   BackgammonDice,
@@ -158,7 +159,9 @@ export class Dice {
   }
 
   static rollDie = function rollDie(): BackgammonDieValue {
-    return (Math.floor(Math.random() * 6) + 1) as BackgammonDieValue
+    // randomInt(1, 7) is exclusive on upper bound → yields 1..6 uniformly from
+    // Node's CSPRNG; cast narrows number → BackgammonDieValue (1|2|3|4|5|6).
+    return randomInt(1, 7) as BackgammonDieValue
   }
   // Convenience  mostly for tests
   static _RandomRoll = [this.rollDie(), this.rollDie()] as BackgammonRoll


### PR DESCRIPTION
## Summary

Replaces `Math.random` with Node's `crypto.randomInt` in `Dice.rollDie`. Phase 1.1 of the dice-fairness hardening plan tracked in [nodots/backgammon#327](https://github.com/nodots/backgammon/issues/327), sub-issue [#330](https://github.com/nodots/backgammon/issues/330).

## Change

```diff
+import { randomInt } from 'crypto'
 …
 static rollDie = function rollDie(): BackgammonDieValue {
-  return (Math.floor(Math.random() * 6) + 1) as BackgammonDieValue
+  // randomInt(1, 7) is exclusive on upper bound → yields 1..6 uniformly from
+  // Node's CSPRNG; cast narrows number → BackgammonDieValue (1|2|3|4|5|6).
+  return randomInt(1, 7) as BackgammonDieValue
 }
```

`randomInt(min, max)` is exclusive on the upper bound, so `randomInt(1, 7)` returns 1–6 uniformly — identical distribution to the previous code, cryptographically secure primitive.

## Why

In an open-information game like backgammon, `Math.random` (V8's xorshift128+) is sufficient for uniform distribution — the relevant property. `crypto.randomInt` adds no statistical improvement but closes the "not cryptographically secure" critique the community has learned to look for. See [docs/white-papers/12-dice-fairness.md §3 and §9.1](https://github.com/nodots/backgammon/pull/329) for the full rationale.

## Test plan

- [x] 14/14 dice tests pass, including the 100k-roll Monte Carlo suite (`packages/core/src/Dice/__tests__/dice.test.ts`).
- [x] Observed distribution on the new primitive: individual faces 16.50–16.86%, doubles 16.72%, all inside the existing ±5% / ±10% bounds.
- [x] Full core test suite: 460 pass. One pre-existing failure in `Game/__tests__/move-and-finalize.test.ts` is unrelated (fails identically on clean `development` without this change).
- [x] `tsc --noEmit` clean.

## Out of scope

`Math.random` is also used in:
- `src/Game/index.ts:97` — random direction assignment at game creation.
- `src/index.ts:18` — `randomBoolean` utility, used for game-setup color/direction picks.

Both are game-setup concerns rather than dice, and fall outside #330's scope. Will file a follow-up.

## Related

- Tracker: [nodots/backgammon#327](https://github.com/nodots/backgammon/issues/327)
- Sub-issue: [nodots/backgammon#330](https://github.com/nodots/backgammon/issues/330)
- White paper: [nodots/backgammon#329](https://github.com/nodots/backgammon/pull/329) (stacked on #328)