### PR TITLE
fix(tests): repair two pre-existing/regression core test failures

### DIFF
--- a/src/Game/__tests__/move-and-finalize.test.ts
+++ b/src/Game/__tests__/move-and-finalize.test.ts
@@ -21,11 +21,16 @@ describe('Game.moveAndFinalize()', () => {
   it("transitions to 'moved' when only one die is usable (6 blocked, 1 used)", () => {
     // Board setup for counterclockwise (black) player:
     // - Black checker at CC 24
-    // - CC 23 empty (die 1 is legal)
-    // - CC 18 has two white checkers (die 6 is blocked)
+    // - CC 23 empty (die 1 is legal: CC 24 → CC 23)
+    // - CC 18 has two white checkers (blocks die 6 from CC 24)
+    // - CC 17 has two white checkers (blocks die 6 from CC 23,
+    //   i.e. even after die 1 is played, die 6 has no legal
+    //   destination from the new position — only then is die 6
+    //   truly "blocked" and the turn should auto-complete).
     const boardImport: BackgammonCheckerContainerImport[] = [
       pointCC(24, 1, 'black'), // origin
-      pointCC(18, 2, 'white'), // block die 6 destination
+      pointCC(18, 2, 'white'), // block die 6 from CC 24
+      pointCC(17, 2, 'white'), // block die 6 from CC 23 (after die 1)
       // leave 23 empty so die 1 is usable
     ]
 

--- a/src/Play/__tests__/play.test.ts
+++ b/src/Play/__tests__/play.test.ts
@@ -95,7 +95,9 @@ describe('Play', () => {
     test('should handle doubles correctly', () => {
       const board = createTestBoard()
       const inactiveDice = Dice.initialize('white') as BackgammonDiceInactive
-      jest.spyOn(Math, 'random').mockReturnValue(0) // This will make both dice roll 1
+      // Mock Dice.rollDie (not Math.random): the primitive moved to
+      // crypto.randomInt in 846c15f, so a Math.random mock is now a no-op.
+      const rollDieSpy = jest.spyOn(Dice, 'rollDie').mockReturnValue(1)
       const player = Player.initialize(
         'white',
         'clockwise',
@@ -121,7 +123,7 @@ describe('Play', () => {
         '\nASCII board after successful doubles test:\n' +
           Board.getAsciiBoard(board)
       )
-      jest.spyOn(Math, 'random').mockRestore()
+      rollDieSpy.mockRestore()
     })
 
     // test('should handle no possible moves', () => {


### PR DESCRIPTION
## Summary

Two test fixes in one PR. Both surfaced by running the full core suite for the first time in a while.

### Commit 1 — \`fix(play): update doubles test to mock Dice.rollDie\`

Regression from [#126](https://github.com/nodots/backgammon-core/pull/126) (Phase 1.1 CSPRNG swap).

\`src/Play/__tests__/play.test.ts\` 'should handle doubles correctly' mocked \`Math.random\` to force doubles of 1s:
\`\`\`ts
jest.spyOn(Math, 'random').mockReturnValue(0) // This will make both dice roll 1
\`\`\`
After #126, \`Dice.rollDie\` calls \`crypto.randomInt\`, not \`Math.random\`. The mock is a no-op; the test passes only when the real CSPRNG happens to roll doubles (≈1/6 of runs). Replaced with a direct \`jest.spyOn(Dice, 'rollDie').mockReturnValue(1)\`.

### Commit 2 — \`fix(game): block CC 17 in moveAndFinalize test\`

Pre-existing failure (dates to the test's introduction in Nov 2025; flagged in memory as "pre-existing"). The test 'transitions to \`moved\` when only one die is usable (6 blocked, 1 used)' asserted die 6 was blocked, but the board setup only blocked CC 18 (die 6 from CC 24). After die 1 (CC 24 → CC 23), die 6 becomes legal again (CC 23 → CC 17, which was empty). The engine correctly kept \`stateKind: 'moving'\`; the test expected \`'moved'\`.

Runtime trace (confirmed with an ephemeral test before fixing):
\`\`\`
STATE moving
MOVES [{die:6, state:"ready", kind:"point-to-point"},
       {die:1, state:"completed", kind:"point-to-point"}]
DIE6_AFTER 1 [{from:23, to:17}]
\`\`\`

Fix: block CC 17 with two whites so die 6 has no legal destination regardless of move order. \`checkAndCompleteTurn\` then auto-completes it as \`no-move\` and the game transitions to \`'moved'\`, matching the test name.

## Test plan

- [x] Target tests each pass 5/5 consecutive runs (deterministic).
- [x] Full core suite: **67/67 suites pass, 434 pass, 12 skipped, zero failures** — first all-green run in memory.
- [x] \`tsc --noEmit\` clean.

## Out of scope

Three other stale \`Math.random\` mocks remain in \`play.test.ts\` on code paths that immediately override \`rolledPlayer.dice.currentRoll\` (lines 46, 192, 216). They were dead even before CSPRNG — passing for the wrong reason. Kept out of scope to keep the PR tight; worth a cosmetic cleanup later.

## Postmortem

Both failures should have been caught before. Noted for future Phase 1.x core work: run \`npx jest\` on the whole package (not just the file under change) before opening a PR.