### PR TITLE
refactor(game): extract guards.ts pure predicates (Phase 1 of #132)

### DIFF
--- a/src/Game/guards.ts
+++ b/src/Game/guards.ts
@@ -1,0 +1,45 @@
+import { BackgammonGame } from '@nodots/backgammon-types'
+
+/**
+ * Validates if rolling is allowed in the current game state.
+ */
+export function canRoll(game: BackgammonGame): boolean {
+  return (
+    game.stateKind === 'rolled-for-start' ||
+    game.stateKind === 'rolling' ||
+    game.stateKind === 'doubled'
+  )
+}
+
+/**
+ * Validates if rolling for start is allowed in the current game state.
+ */
+export function canRollForStart(game: BackgammonGame): boolean {
+  return game.stateKind === 'rolling-for-start'
+}
+
+/**
+ * Validates if the specified player can roll in the current game state.
+ */
+export function canPlayerRoll(game: BackgammonGame, playerId: string): boolean {
+  if (!canRoll(game)) {
+    return false
+  }
+
+  // Check if the player is the active player
+  if (game.activeColor) {
+    const activePlayer = game.players.find((p) => p.color === game.activeColor)
+    if (!activePlayer || activePlayer.id !== playerId) {
+      return false
+    }
+  }
+
+  return true
+}
+
+/**
+ * Validates if moves can be calculated for the current game state.
+ */
+export function canGetPossibleMoves(game: BackgammonGame): boolean {
+  return game.stateKind === 'moving'
+}

--- a/src/Game/index.ts
+++ b/src/Game/index.ts
@@ -37,6 +37,12 @@ import { Dice } from '../Dice'
 import { BackgammonMoveDirection, Play } from '../Play'
 import type { MoveExecutionOptions } from '../Play'
 import { debug, logger } from '../utils/logger'
+import {
+  canGetPossibleMoves,
+  canPlayerRoll,
+  canRoll,
+  canRollForStart,
+} from './guards'
 import { createBaseGameProperties, incrementStateVersion } from './shared'
 
 export * from '../index'
@@ -2004,46 +2010,28 @@ export class Game {
    * Validates if rolling is allowed in the current game state
    */
   public static canRoll(game: BackgammonGame): boolean {
-    return (
-      game.stateKind === 'rolled-for-start' ||
-      game.stateKind === 'rolling' ||
-      game.stateKind === 'doubled'
-    )
+    return canRoll(game)
   }
 
   /**
    * Validates if rolling for start is allowed in the current game state
    */
   public static canRollForStart(game: BackgammonGame): boolean {
-    return game.stateKind === 'rolling-for-start'
+    return canRollForStart(game)
   }
 
   /**
    * Validates if the specified player can roll in the current game state
    */
   public static canPlayerRoll(game: BackgammonGame, playerId: string): boolean {
-    if (!Game.canRoll(game)) {
-      return false
-    }
-
-    // Check if the player is the active player
-    if (game.activeColor) {
-      const activePlayer = game.players.find(
-        (p) => p.color === game.activeColor
-      )
-      if (!activePlayer || activePlayer.id !== playerId) {
-        return false
-      }
-    }
-
-    return true
+    return canPlayerRoll(game, playerId)
   }
 
   /**
    * Validates if moves can be calculated for the current game state
    */
   public static canGetPossibleMoves(game: BackgammonGame): boolean {
-    return game.stateKind === 'moving'
+    return canGetPossibleMoves(game)
   }
 
   // --- Checker Management ---


### PR DESCRIPTION
## Phase 1 of the Game/index.ts decomposition epic (#133)

**Stacked on #135 (Phase 0).** Base is `refactor/game-decomp-phase0-shared`; review/merge #135 first, then this retargets to `development`.

### What changed
- New `src/Game/guards.ts` (leaf module) holds the pure turn/roll predicates `canRoll`, `canRollForStart`, `canPlayerRoll`, `canGetPossibleMoves` as free functions.
- The public `Game.can*` static methods stay as thin delegating wrappers, so external callers in ai/api/client see no API change — first use of the facade-delegation pattern the rest of the epic follows.
- `canPlayerRoll` calls the module-local `canRoll` directly (**Rule A**: extracted functions never route back through the `Game` facade).
- Cube predicates (`canOfferDouble`/`canAcceptDouble`/`canRefuseDouble`) and `canUndoActivePlay` are intentionally left for their concern-specific modules (cube.ts / undo.ts).

### Verification
- `tsc -b --force` clean
- `npx jest`: 448 passed / 12 skipped (identical to baseline)
- No behavior change; no public API change

Refs #132, #133