### PR TITLE
refactor(game): prune dead imports + finalize facade (Phase 7 of #132)

### DIFF
--- a/src/Game/index.ts
+++ b/src/Game/index.ts
@@ -3,8 +3,6 @@ import {
   BackgammonChecker,
   BackgammonColor,
   BackgammonCube,
-  BackgammonCubeValue,
-  BackgammonDieValue,
   BackgammonGame,
   BackgammonGameDoubled,
   BackgammonGameMoving,
@@ -12,19 +10,15 @@ import {
   BackgammonGameRolling,
   BackgammonGameRollingForStart,
   BackgammonGameStateKind,
-  BackgammonMoveSkeleton,
   BackgammonPlay,
   BackgammonPlayer,
   BackgammonPlayerActive,
-  BackgammonPlayerDoubled,
   BackgammonPlayerInactive,
   BackgammonPlayerMoving,
   BackgammonPlayerRolledForStart,
   BackgammonPlayerRolling,
   BackgammonPlayers,
-  BackgammonPlayerWinner,
   BackgammonPlayMoving,
-  BackgammonRoll,
 } from '@nodots/backgammon-types'
 import { generateId, Player } from '..'
 import { Board } from '../Board'
@@ -72,10 +66,8 @@ export * from '../index'
 // Import tuple aliases from types package
 import type {
   BackgammonGameCompleted,
-  BackgammonPlayersMovingTuple,
   BackgammonPlayersRolledForStartTuple,
   BackgammonPlayersRollingForStartTuple,
-  BackgammonPlayersRollingTuple,
 } from '@nodots/backgammon-types'
 import { executeRobotTurn } from './executeRobotTurn'
 


### PR DESCRIPTION
## Phase 7 (final) of the Game/index.ts decomposition epic (#133)

**Stacked on #141 (Phase 6).** Retarget to `development` as parents merge.

`index.ts` is now a thin facade over `shared` / `guards` / `undo` / `cube` / `lifecycle` / `turnFlow` / `robot`. `Game` remains a class (constructor path + `gnuPositionId` getter), `createNewGame` / `initialize` / the player accessors stay on it, and every public `Game.*` method delegates to a free function.

### What changed
- Removed type imports left dead by the extractions: `BackgammonCubeValue`, `BackgammonDieValue`, `BackgammonMoveSkeleton`, `BackgammonPlayerDoubled`, `BackgammonPlayerWinner`, `BackgammonRoll`, `BackgammonPlayersMovingTuple`, `BackgammonPlayersRollingTuple`.

### Downstream guard
Rebuilt core and typechecked consumers against the local build:
- `ai` — `tsc -b` clean
- `api` — `tsc --noEmit` clean
- `client` — does not consume core at the type level (only doc/marketing string literals)

Public `Game.*` API + signatures were preserved through every phase, so no consumer changes were needed.

### Epic result
**`Game/index.ts`: 2491 → 531 lines (−79%)**, 27 new characterization tests, `tsc -b` clean and 475 tests passing at every phase.

Refs #132, #133