### PR TITLE
refactor(game): remove as-any casts in cube + snapshot paths (Phase 9 of #96)

### DIFF
--- a/src/Game/cube.ts
+++ b/src/Game/cube.ts
@@ -35,7 +35,7 @@ export function canOfferDouble(
     game.cube.stateKind !== 'offered' &&
     (!game.cube.owner || game.cube.owner.id === player.id) &&
     // Disallow repeat doubles in same turn unless Beaver is implemented
-    (game.cube as any).offeredThisTurnBy?.id !== player.id
+    game.cube.offeredThisTurnBy?.id !== player.id
   )
 }
 
@@ -107,13 +107,16 @@ export function acceptDouble(
     ...offeringPlayer,
     stateKind: 'rolling',
     dice: Dice.initialize(offeringPlayer.color, 'rolling'),
-    rollForStartValue: (offeringPlayer as any).rollForStartValue,
+    // Non-null: an active player mid-game has a rollForStartValue; the base
+    // player type declares it optional, the rolling player type requires it.
+    rollForStartValue: offeringPlayer.rollForStartValue!,
   }
   const updatedInactivePlayer: BackgammonPlayerInactive = {
     ...player,
     stateKind: 'inactive',
     dice: Dice.initialize(player.color, 'inactive'),
-    rollForStartValue: (player as any).rollForStartValue,
+    // Non-null: see above; inactive player type also requires rollForStartValue.
+    rollForStartValue: player.rollForStartValue!,
   }
 
   const updatedPlayers = game.players.map((p) => {
@@ -130,8 +133,10 @@ export function acceptDouble(
     activePlayer: updatedActivePlayer,
     inactivePlayer: updatedInactivePlayer,
     activeColor: updatedActivePlayer.color,
-    activePlay: undefined as any,
-  } as any)
+    activePlay: undefined,
+    // as unknown as BackgammonGameRolling: the spread yields a generic players
+    // array (not the rolling-game tuple) that TS can't narrow structurally.
+  } as unknown as BackgammonGameRolling)
 }
 
 export function canRefuseDouble(

--- a/src/Game/index.ts
+++ b/src/Game/index.ts
@@ -88,6 +88,8 @@ export class Game {
    */
   get gnuPositionId(): string {
     try {
+      // as any: the Game class instance is structurally a BackgammonGame but
+      // TS does not treat the class as assignable to the discriminated union.
       return exportToGnuPositionId(this as any)
     } catch (error) {
       logger.warn('Failed to generate gnuPositionId:', error)

--- a/src/Game/turnFlow.ts
+++ b/src/Game/turnFlow.ts
@@ -752,14 +752,14 @@ export function move(
 ): BackgammonGameMoving | BackgammonGameMoved | BackgammonGameCompleted {
   // Push a pre-move snapshot to the turn-local undo stack
   try {
-    const ap: any = (game as any).activePlay
+    const ap = game.activePlay
     if (ap) {
-      if (!ap.undo) ap.undo = { frames: [] }
+      const undo = ap.undo ?? (ap.undo = { frames: [] })
       const snapshot =
         typeof structuredClone === 'function'
           ? structuredClone(game)
-          : (JSON.parse(JSON.stringify(game)) as any)
-      ap.undo.frames.push(snapshot)
+          : (JSON.parse(JSON.stringify(game)) as BackgammonGameMoving)
+      undo.frames.push(snapshot)
     }
   } catch (e) {
     logger?.warn?.('Failed to push undo snapshot in Game.move', e)
@@ -1207,14 +1207,14 @@ export function executeAndRecalculate(
 
   // Push a pre-move snapshot
   try {
-    const ap: any = (game as any).activePlay
+    const ap = game.activePlay
     if (ap) {
-      if (!ap.undo) ap.undo = { frames: [] }
+      const undo = ap.undo ?? (ap.undo = { frames: [] })
       const snapshot =
         typeof structuredClone === 'function'
           ? structuredClone(game)
-          : (JSON.parse(JSON.stringify(game)) as any)
-      ap.undo.frames.push(snapshot)
+          : (JSON.parse(JSON.stringify(game)) as BackgammonGameMoving)
+      undo.frames.push(snapshot)
     }
   } catch (e) {
     logger?.warn?.('Failed to push undo snapshot before move', e)


### PR DESCRIPTION
## Phase 9 of the epic (#133) — `as any` removal (#96)

**Stacked on #143 (Phase 8).** Retarget to `development` as parents merge.

Continues the `#96` cast removal beyond the undo slice (done in Phase 2).

### cube.ts — all 5 `as any` removed
- `offeredThisTurnBy` is declared on `BaseCube`, so `(game.cube as any).offeredThisTurnBy` was unnecessary.
- `rollForStartValue` is on `BasePlayerProps` (optional) but required on the rolling/inactive player types → the two player-copy casts become documented non-null assertions.
- The `acceptDouble` return `as any` narrows to a commented `as unknown as BackgammonGameRolling` (the spread yields a generic players array TS can't narrow to the tuple shape).

### turnFlow.ts — undo-snapshot casts removed
`game.activePlay` and `undo.frames` are typed now (since the Phase 2 types fix), so the `const ap: any = (game as any).activePlay` blocks in `move()` and `executeAndRecalculate()` — plus their JSON-fallback `as any` — are gone, replaced by a typed `ap.undo ?? (ap.undo = { frames: [] })`.

### index.ts
The `gnuPositionId` getter's `this as any` now carries the required explanatory comment (Game class vs `BackgammonGame` union).

### Deferred
`turnFlow.ts` still has ~30 `(move as any).x =` casts in the sanitization/recalculation loops. Removing them means rebuilding move objects immutably instead of mutating in place — a behavior-sensitive change in the hottest game path, left for a dedicated pass now that `turnFlow` has ~76% coverage.

### Verification
- `tsc -b --force` clean
- `npx jest`: 518 passed / 12 skipped, unchanged

Refs #96