### PR TITLE
Require backgammon-types ^1.0.5, which is what the code already needs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@nodots/backgammon-core",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nodots/backgammon-core",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "GPL-3.0",
       "dependencies": {
-        "@nodots/backgammon-types": "^1.0.3",
+        "@nodots/backgammon-types": "^1.0.5",
         "@nodots/gnubg-hints": "^1.0.0",
         "uuid": "^11.1.0"
       },
@@ -1330,9 +1330,9 @@
       }
     },
     "node_modules/@nodots/backgammon-types": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@nodots/backgammon-types/-/backgammon-types-1.0.3.tgz",
-      "integrity": "sha512-2o3jTgG2pioUTKUZshE9lDnwl/D4u5y+nA+Y7fBJsR6pzgF8O+BLDfIZigTsa91zodU6uIOLnpUoq+XaSyrw9A==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@nodots/backgammon-types/-/backgammon-types-1.0.5.tgz",
+      "integrity": "sha512-IHI/t+Jf7yXvy36afla7q3tl+qEpKy2gY6OGRNSNpLh7nllDrAVp5T79e3QfEkSKELH/QbeFXCmnJkE+18cI+A==",
       "license": "GPL-3.0",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@nodots/backgammon-types": "^1.0.3",
+    "@nodots/backgammon-types": "^1.0.5",
     "@nodots/gnubg-hints": "^1.0.0",
     "uuid": "^11.1.0"
   },


### PR DESCRIPTION
`development` has been red since **2026-07-27**. This is the whole of the fix.

## What broke

The resignation-offer merge (`50793d1`) started using `BackgammonResignationOffer` in `src/Game/cube.ts` but left the dependency range at `^1.0.3`. That range is satisfied by 1.0.3, so npm had no reason to move off it, and the committed lock stayed on a types version that does not export the member.

`npm ci` obeys the lock, installs 1.0.3, and the build dies with eight errors in `src/Game/cube.ts` — `TS2305: Module '@nodots/backgammon-types' has no exported member 'BackgammonResignationOffer'`, plus the knock-on `TS2339`s and two `TS2352`s.

It passes on a developer machine because `node_modules` there has 1.0.5 from a manual `npm install`. That divergence between the lock and the installed tree is what hid this for three days.

Note that `npm install --package-lock-only` does **not** fix it — npm keeps a lock entry that still satisfies the declared range. The range itself had to change, and it should: the code genuinely requires 1.0.5.

## Also in the diff

The lock's own `@nodots/backgammon-core` version catches up 1.0.2 → 1.0.3 to match `package.json` — a stale sync left behind by the 1.0.3 release commit `02e63ef`. Nothing else in the lock moves.

## Testing

`npm run build` clean. `npx jest src/Game/__tests__` — 126 pass, 4 skipped, 20 suites.

Not verified locally: a from-scratch `npm ci`. This PR's CI run is the real check, since reproducing the failure locally means discarding the working `node_modules`.

## Unresolved, and not addressed here

Three suites — `gnuPositionId`, `gnuPositionIdBar`, and a sibling — crash with SIGABRT on this machine: the native gnubg addon aborts at `EvalInitialise` because `gnubg.wd` and `gnubg.weights` are absent from `node_modules`. That reproduces on `development` too and is unrelated to this change, but it means core's position-id tests are not running locally.

The same stale-range pattern may exist in `backgammon-ai`, `backgammon-api` and `backgammon-client`, which the resignation chain also touched. Unchecked.

Blocks #147.